### PR TITLE
Sonarcube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ language: python
 sudo: false
 python:
     - "3.7.4"
-# install:
-#     - "bash CI-install.sh"
+install:
+    - "bash CI-install.sh"
 script:
     - "sonar-scanner"
     - "bash CI-script-framework.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ python:
 install:
     - "bash CI-install.sh"
 script:
+    - "sonar-scanner"
     - "bash CI-script-framework.sh"
     - "bash CI-script-fedavg.sh"
     - "bash CI-script-fednas.sh"
     - "bash CI-script-fedavg-robust.sh"
-    - "sonar-scanner"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ language: python
 sudo: false
 python:
     - "3.7.4"
-install:
-    - "bash CI-install.sh"
+# install:
+#     - "bash CI-install.sh"
 script:
     - "sonar-scanner"
     - "bash CI-script-framework.sh"

--- a/contributor.md
+++ b/contributor.md
@@ -32,3 +32,5 @@ Bill Yuchen Lin, PhD student, USC, USA
 Yanfang Li, MS, USC, USA; Project Manager
 
 Rodrigo Pecchio, BA in CS, USC, USA; will join AWS after graduation.
+
+Ákos Gángoly, MSc in CS, BME, Hungary

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,7 @@ sonar.organization=fedml-ai
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 #sonar.sources=.
+sonar.exclusions=fedml_mobile/**
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
sonarcube ignores fedml_mobile (java is not supported in the free tier)

Results can be viewed here: https://sonarcloud.io/dashboard?id=FedML-AI_FedML
The CI-install script is failing, so there is nothing on the master. 
So, I temporarily disabled it on the sonarcube branch. Here is what I got: https://sonarcloud.io/dashboard?branch=sonarcube&id=FedML-AI_FedML