### PR TITLE
Some modifications to restore accuracy on FedAVG

### DIFF
--- a/fedml_api/standalone/fedavg/my_model_trainer_classification.py
+++ b/fedml_api/standalone/fedavg/my_model_trainer_classification.py
@@ -40,8 +40,8 @@ class MyModelTrainer(ModelTrainer):
                 loss = criterion(log_probs, labels)
                 loss.backward()
 
-                # to avoid nan loss
-                torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
+                # Uncommet this following line to avoid nan loss
+                # torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
 
                 optimizer.step()
                 # logging.info('Update Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(

--- a/fedml_experiments/distributed/fedavg/main_fedavg.py
+++ b/fedml_experiments/distributed/fedavg/main_fedavg.py
@@ -84,7 +84,7 @@ def add_args(parser):
     parser.add_argument('--lr', type=float, default=0.001, metavar='LR',
                         help='learning rate (default: 0.001)')
 
-    parser.add_argument('--wd', help='weight decay parameter;', type=float, default=0.001)
+    parser.add_argument('--wd', help='weight decay parameter;', type=float, default=0.0001)
 
     parser.add_argument('--epochs', type=int, default=5, metavar='EP',
                         help='how many epochs will be trained locally')


### PR DESCRIPTION
In the current FedML master, I trained FedAVG and got low accuracy. In original version, there is no grad clip [[here](https://github.com/FedML-AI/FedML/blob/d5098116169c3999a98efceb80092469bb1af317/fedml_api/distributed/fedavg/FedAVGTrainer.py#L44)] and weight decay is 0.0001[[here](https://github.com/FedML-AI/FedML/blob/d5098116169c3999a98efceb80092469bb1af317/fedml_api/distributed/fedavg/FedAVGTrainer.py#L22)].Modifying these two lines will restore accuracy. This may have contributed to the problem.It looks better after modification, and accuracy is still lower than the original version.
Before modification[[here](https://wandb.ai/aaaaltaaaa/fedml/reports/before-modification--Vmlldzo5MzUwMjU?accessToken=oo11uwm5tz7gjtydeo3as3gh7n30e977isxh9h0ghbf9usjn62b5negpip0cp8td)]
After modification[[here](https://wandb.ai/aaaaltaaaa/fedml/reports/after-modification--Vmlldzo5MzUwMDU?accessToken=tewsfsnwlevwpcfwgfgn4n9pkeq5x12u4qenm5p2vrmnrvhniy2cyq4suzc0d45b)]