### PR TITLE
Add missing dependency to CI-install.sh

### DIFF
--- a/CI-install.sh
+++ b/CI-install.sh
@@ -35,6 +35,7 @@ conda install numpy
 conda install h5py
 conda install setproctitle
 conda install networkx
+conda install tqdm
 pip install -r requirements.txt
 
 # install the dataset


### PR DESCRIPTION
When installing FedML on Ubuntu 18.04, I got an error about tqdm not being installed. This PR updates the script to install tqdm.