### PR TITLE
update lending_club_loan download link

### DIFF
--- a/data/lending_club_loan/README.md
+++ b/data/lending_club_loan/README.md
@@ -1,2 +1,2 @@
 Please manually download "loan.csv" file into this directory.
-Download link: https://www.kaggle.com/wendykan/lending-club-loan-data
+Download link: https://www.kaggle.com/wordsforthewise/lending-club


### PR DESCRIPTION
The original url is invalid currently. The kaggler [wendykan](https://www.kaggle.com/wendykan/datasets) might have deleted this dataset. The new url has the most up-to-date lending club data.