### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ruamel.yaml==0.16.10
 ruamel.yaml.clib==0.2.0
 flask==1.1.2
 gunicorn==20.0.4
-gevent==20.6.2
+gevent==20.9.0
 paho-mqtt==1.5.0
 Celery==5.2.2
 dill==0.3.3


### PR DESCRIPTION
Update gevent from version 20.6.2 to 20.9.0 to prevent the issue of 
"RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144, got 152 return f(*args, **kwds)"