### PR TITLE
Fix Bugs When Aggregator Distributing Different Model Params to Clients

### DIFF
--- a/python/fedml/cross_silo/server/fedml_aggregator.py
+++ b/python/fedml/cross_silo/server/fedml_aggregator.py
@@ -198,4 +198,21 @@ class FedMLAggregator(object):
             logging.info("key_metrics_on_last_round = {}".format(key_metrics_on_last_round))
         else:
             mlops.log({"round_idx": round_idx})
+    
+    def get_dummy_input_tensor(self):
+        from torch.utils.data import DataLoader
 
+        testloader = DataLoader(self.test_global, batch_size=1, shuffle=False)
+        with torch.no_grad():
+            batch_idx, features_and_lable = next(enumerate(testloader))
+        
+        features = features_and_lable[:-1]  # TODO: Process Multi-Label
+        return features
+    
+    def save_dummy_input_tensor(self):
+        import pickle
+        features = self.get_input_size_type()
+        with open('dummy_input_tensor.pkl', 'wb') as handle:
+            pickle.dump(features, handle)
+
+        # TODO: save the dummy_input_tensor.pkl to s3, and transfer when click "Create Model Card"

--- a/python/fedml/cross_silo/server/fedml_aggregator.py
+++ b/python/fedml/cross_silo/server/fedml_aggregator.py
@@ -87,7 +87,12 @@ class FedMLAggregator(object):
         averaged_params = self.aggregator.aggregate(model_list)
 
         if type(averaged_params) is dict:
-            for client_index in range(len(averaged_params)):
+            if len(averaged_params) == self.client_num + 1: # aggregator pass extra {-1 : global_parms_dict}  as global_params
+                itr_count = len(averaged_params) - 1        # do not apply on_after_aggregation to client -1
+            else:
+                itr_count = len(averaged_params)
+
+            for client_index in range(itr_count):
                 averaged_params[client_index] = self.aggregator.on_after_aggregation(averaged_params[client_index])
         else:
             averaged_params = self.aggregator.on_after_aggregation(averaged_params)

--- a/python/fedml/cross_silo/server/fedml_server_manager.py
+++ b/python/fedml/cross_silo/server/fedml_server_manager.py
@@ -167,6 +167,10 @@ class FedMLServerManager(FedMLCommManager):
 
             self.aggregator.test_on_server_for_all_clients(self.args.round_idx)
 
+            # TODO: Utilize aggregator.save_dummy_input_tensor()
+            # to send output input size and type (saved as pickle) to s3,
+            # and transfer when click "Create Model Card" 
+
             self.aggregator.assess_contribution()
 
             mlops.event("server.agg_and_eval", event_started=False, event_value=str(self.args.round_idx))

--- a/python/fedml/cross_silo/server/fedml_server_manager.py
+++ b/python/fedml/cross_silo/server/fedml_server_manager.py
@@ -191,15 +191,21 @@ class FedMLServerManager(FedMLCommManager):
             for receiver_id in self.client_id_list_in_this_round:
                 client_index = self.data_silo_index_list[client_idx_in_this_round]
                 if type(global_model_params) is dict:
-                    global_model_url, global_model_key = self.send_message_sync_model_to_client(
-                        receiver_id, global_model_params[client_index], client_index, global_model_url,
-                        global_model_key
+                    # compatible with the old version that, user did not give {-1 : global_parms_dict}
+                    global_model_url, global_model_key = self.send_message_diff_sync_model_to_client(
+                        receiver_id, global_model_params[client_index], client_index
                     )
                 else:
                     global_model_url, global_model_key = self.send_message_sync_model_to_client(
                         receiver_id, global_model_params, client_index, global_model_url, global_model_key
                     )
                 client_idx_in_this_round += 1
+
+            # if user give {-1 : global_parms_dict}, then record global_model url separately
+            if type(global_model_params) is dict and (-1 in global_model_params.keys()):
+                global_model_url, global_model_key = self.send_message_diff_sync_model_to_client(
+                    -1, global_model_params[-1], -1
+                )
 
             self.args.round_idx += 1
             mlops.log_aggregated_model_info(
@@ -267,4 +273,20 @@ class FedMLServerManager(FedMLCommManager):
         global_model_url = message.get(MyMessage.MSG_ARG_KEY_MODEL_PARAMS_URL)
         global_model_key = message.get(MyMessage.MSG_ARG_KEY_MODEL_PARAMS_KEY)
 
+        return global_model_url, global_model_key
+
+    def send_message_diff_sync_model_to_client(self, receive_id, client_model_params, client_index):
+        tick = time.time()
+        logging.info("send_message_sync_model_to_client. receive_id = %d" % receive_id)
+        message = Message(MyMessage.MSG_TYPE_S2C_SYNC_MODEL_TO_CLIENT, self.get_sender_id(), receive_id, )
+        message.add_params(MyMessage.MSG_ARG_KEY_MODEL_PARAMS, client_model_params)
+        message.add_params(MyMessage.MSG_ARG_KEY_CLIENT_INDEX, str(client_index))
+        message.add_params(MyMessage.MSG_ARG_KEY_CLIENT_OS, "PythonClient")
+        self.send_message(message)
+
+        MLOpsProfilerEvent.log_to_wandb({"Communiaction/Send_Total": time.time() - tick})
+
+        global_model_url = message.get(MyMessage.MSG_ARG_KEY_MODEL_PARAMS_URL)
+        global_model_key = message.get(MyMessage.MSG_ARG_KEY_MODEL_PARAMS_KEY)
+        
         return global_model_url, global_model_key


### PR DESCRIPTION
In the recommendation case, after the server aggregates the embedding from the client, it needs to distribute different parts of the global embedding to different clients.

However, in the current version of FedML architecture:
(1) The server will FALSELY send the FIRST client's embedding to EVERY client.
(2) The global_model is NOT correctly recorded in the S3 due to the URL processing logic.

These can be fixed by:
(1) For each client, the server will generate a new URL and send it to the client.
(2) For the global params, it should be transferred by USER to the aggregate server using the following formats.

{
    -1:  self. model.state_dict()     # adding global params
     0:  ...                                         # embedding send to client 0
     1:  ...                                          # embedding send to client 1
}

E.g. Usage:
aggregated_model_params_map[-1] = self.model.state_dict()
return aggregated_model_params_map

