### PR TITLE
Fix Bugs: Avoid Repeatly Printing Download Progess

### DIFF
--- a/python/fedml/cli/edge_deployment/client_runner.py
+++ b/python/fedml/cli/edge_deployment/client_runner.py
@@ -135,11 +135,16 @@ class FedMLClientRunner:
 
         downloaded = count * blksize
         downloaded = filesize if downloaded > filesize else downloaded
-        progress_int = (downloaded / filesize * 100) if filesize != 0 else 0
-        progress = format(progress_int, '.2f')
+        progress = (downloaded / filesize * 100) if filesize != 0 else 0
+        progress_int = int(progress)
         downloaded_kb = format(downloaded/1024, '.2f')
-        if progress_int <= 0 or (int(progress_int) % 5 == 0):
-            logging.info("package downloaded size {} KB, progress {}%".format(downloaded_kb, progress))
+        
+        # since this hook funtion is stateless, we need a state to avoid print progress repeatly
+        if count == 0:
+            self.prev_download_progress = 0 
+        if progress_int != self.prev_download_progress and progress_int % 5 == 0:
+            self.prev_download_progress = progress_int
+            logging.info("package downloaded size {} KB, progress {}%".format(downloaded_kb, progress_int))
 
     def retrieve_and_unzip_package(self, package_name, package_url):
         local_package_path = ClientConstants.get_package_download_dir()

--- a/python/fedml/cli/model_deployment/device_client_runner.py
+++ b/python/fedml/cli/model_deployment/device_client_runner.py
@@ -142,11 +142,16 @@ class FedMLClientRunner:
 
         downloaded = count * blksize
         downloaded = filesize if downloaded > filesize else downloaded
-        progress_int = (downloaded / filesize * 100) if filesize != 0 else 0
-        progress = format(progress_int, '.2f')
+        progress = (downloaded / filesize * 100) if filesize != 0 else 0
+        progress_int = int(progress)
         downloaded_kb = format(downloaded/1024, '.2f')
-        if progress_int <= 0 or (int(progress_int) % 5 == 0):
-            logging.info("package downloaded size {} KB, progress {}%".format(downloaded_kb, progress))
+        
+        # since this hook funtion is stateless, we need a state to avoid printing progress repeatly
+        if count == 0:
+            self.prev_download_progress = 0 
+        if progress_int != self.prev_download_progress and progress_int % 5 == 0:
+            self.prev_download_progress = progress_int
+            logging.info("package downloaded size {} KB, progress {}%".format(downloaded_kb, progress_int))
 
     def build_dynamic_constrain_variables(self, run_id, run_config):
         pass

--- a/python/fedml/cli/model_deployment/device_server_runner.py
+++ b/python/fedml/cli/model_deployment/device_server_runner.py
@@ -115,11 +115,16 @@ class FedMLServerRunner:
 
         downloaded = count * blksize
         downloaded = filesize if downloaded > filesize else downloaded
-        progress_int = (downloaded / filesize * 100) if filesize != 0 else 0
-        progress = format(progress_int, '.2f')
-        downloaded_kb = format(downloaded / 1024, '.2f')
-        if progress_int <= 0 or (int(progress_int) % 5 == 0):
-            logging.info("package downloaded size {} KB, progress {}%".format(downloaded_kb, progress))
+        progress = (downloaded / filesize * 100) if filesize != 0 else 0
+        progress_int = int(progress)
+        downloaded_kb = format(downloaded/1024, '.2f')
+        
+        # since this hook funtion is stateless, we need a state to avoid printing progress repeatly
+        if count == 0:
+            self.prev_download_progress = 0 
+        if progress_int != self.prev_download_progress and progress_int % 5 == 0:
+            self.prev_download_progress = progress_int
+            logging.info("package downloaded size {} KB, progress {}%".format(downloaded_kb, progress_int))
 
     def retrieve_and_unzip_package(self, package_name, package_url):
         local_package_path = ServerConstants.get_model_package_dir()

--- a/python/fedml/cli/server_deployment/server_runner.py
+++ b/python/fedml/cli/server_deployment/server_runner.py
@@ -152,11 +152,16 @@ class FedMLServerRunner:
 
         downloaded = count * blksize
         downloaded = filesize if downloaded > filesize else downloaded
-        progress_int = (downloaded / filesize * 100) if filesize != 0 else 0
-        progress = format(progress_int, '.2f')
-        downloaded_kb = format(downloaded / 1024, '.2f')
-        if progress_int <= 0 or (int(progress_int) % 5 == 0):
-            logging.info("package downloaded size {} KB, progress {}%".format(downloaded_kb, progress))
+        progress = (downloaded / filesize * 100) if filesize != 0 else 0
+        progress_int = int(progress)
+        downloaded_kb = format(downloaded/1024, '.2f')
+        
+        # since this hook funtion is stateless, we need a state to avoid printing progress repeatly
+        if count == 0:
+            self.prev_download_progress = 0 
+        if progress_int != self.prev_download_progress and progress_int % 5 == 0:
+            self.prev_download_progress = progress_int
+            logging.info("package downloaded size {} KB, progress {}%".format(downloaded_kb, progress_int))
 
     def retrieve_and_unzip_package(self, package_name, package_url):
         local_package_path = ServerConstants.get_package_download_dir()


### PR DESCRIPTION
After Fix:

[FedML-Client @device-id-13484] [Thu, 16 Mar 2023 12:29:41] [INFO] [client_runner.py:149:package_download_progress] package downloaded size 6488.00 KB, progress 5%
[FedML-Client @device-id-13484] [Thu, 16 Mar 2023 12:29:41] [INFO] [client_runner.py:149:package_download_progress] package downloaded size 12968.00 KB, progress 10%
[FedML-Client @device-id-13484] [Thu, 16 Mar 2023 12:29:41] [INFO] [client_runner.py:149:package_download_progress] package downloaded size 19456.00 KB, progress 15%
...