### PR TITLE
Fix Bugs When the ntp port in /etc/services is missing

### DIFF
--- a/python/fedml/core/mlops/mlops_utils.py
+++ b/python/fedml/core/mlops/mlops_utils.py
@@ -6,6 +6,23 @@ import datetime
 
 
 class MLOpsUtils:
+    @staticmethod
+    def get_ntp_port():
+        """
+        Get the ntp server port
+        """
+        # default port is the name of the service but lookup would fail
+        # if the /etc/services file is missing. In that case, fallback to numeric
+        import socket
+        host = 'time.aws.com'
+        port = 'ntp'
+        DEFAULT_PORT_NUM = 123
+        try:
+            socket.getaddrinfo(host, port)
+        except socket.gaierror:
+            port = DEFAULT_PORT_NUM
+
+        return port
 
     @staticmethod
     def get_ntp_offset():
@@ -14,8 +31,13 @@ class MLOpsUtils:
         while True:  # try until we get time offset
             try:
                 ntp_client = ntplib.NTPClient()
+                req_args = {
+                    'host': ntp_server_url,
+                    'port': MLOpsUtils.get_ntp_port(),
+                    'version': 10,
+                }
                 ntp_time = datetime.datetime.utcfromtimestamp(
-                    ntp_client.request(ntp_server_url, 10).tx_time).timestamp()
+                    ntp_client.request(**req_args).tx_time).timestamp()
                 loc_computer_time = time.time()
                 offset = ntp_time - loc_computer_time
                 return offset


### PR DESCRIPTION
Error in sys.excepthook:
Traceback (most recent call last):
 File “/root/fedml-miniconda/envs/fedml-theta-pip/lib/python3.8/site-packages/fedml/core/mlops/mlops_runtime_log.py”, line 103, in get_ntp_offset
  ntp_time = datetime.datetime.utcfromtimestamp(ntp_client.request(ntp_server_url, 10).tx_time).timestamp()
 File “/root/fedml-miniconda/envs/fedml-theta-pip/lib/python3.8/site-packages/ntplib.py”, line 296, in request
  addrinfo = socket.getaddrinfo(host, port)[0]
 File “/root/fedml-miniconda/envs/fedml-theta-pip/lib/python3.8/socket.py”, line 918, in getaddrinfo
  for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -8] Servname not supported for ai_socktype


above error will occur when
"
ntp             123/udp
ntp             123/tcp
"
is missing in in /etc/services.
To Solve such problem, we need to set default value of ntp port to to numeric 123, if and only if we hit gaierror.