### PR TITLE
Added Namespace to helm charts

### DIFF
--- a/devops/k8s/fedml-edge-client-server/fedml-client-deployment/Chart.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-client-deployment/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.8.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.3"
+appVersion: "1.16.0"

--- a/devops/k8s/fedml-edge-client-server/fedml-client-deployment/templates/deployment.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-client-deployment/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "fedml-client-deployment.fullname" . }}
+  namespace: {{  .Values.namespace }}
   labels:
     {{- include "fedml-client-deployment.labels" . | nindent 4 }}
 spec:

--- a/devops/k8s/fedml-edge-client-server/fedml-client-deployment/templates/namespace.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-client-deployment/templates/namespace.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    name: {{ .Values.namespace }}

--- a/devops/k8s/fedml-edge-client-server/fedml-client-deployment/templates/serviceaccount.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-client-deployment/templates/serviceaccount.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "fedml-client-deployment.serviceAccountName" . }}
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{.Values.namespace }}
   labels:
     {{- include "fedml-client-deployment.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/devops/k8s/fedml-edge-client-server/fedml-client-deployment/values.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-client-deployment/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+namespace: fedml
+
 image:
   repository: fedml/fedml-edge-client-server
   pullPolicy: Always
@@ -21,7 +23,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ""
+  name: "fedml"
 
 podAnnotations: {}
 

--- a/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/deployment.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "fedml-server-deployment.fullname" . }}
+  namespace: {{- with .Values.namespace }}
   labels:
     {{- include "fedml-server-deployment.labels" . | nindent 4 }}
 spec:

--- a/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/namespace.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/namespace.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    name: {{ .Values.namespace }}

--- a/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/serviceaccount.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/serviceaccount.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "fedml-server-deployment.serviceAccountName" . }}
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{- with .Values.namespace }}
   labels:
     {{- include "fedml-server-deployment.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/devops/k8s/fedml-edge-client-server/fedml-server-deployment/values.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-server-deployment/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+namespace: fedml
+
 image:
   repository: fedml/fedml-edge-client-server
   pullPolicy: Always
@@ -71,7 +73,7 @@ resources: {}
 autoscaling:
   enabled: false
   minReplicas: 1
-  maxReplicas: 10
+  maxReplicas: 1
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 


### PR DESCRIPTION
Encountered  challenges with automated deployment when namespace was not specified. Added the "fedml" namespace to fedml-client-deployment and fedml-server-deployment