### PR TITLE
add namespace name to fedml-edge-server-deployment

### DIFF
--- a/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/deployment.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "fedml-server-deployment.fullname" . }}
-  namespace: {{- with .Values.namespace }}
+  namespace: {{.Values.namespace }}
   labels:
     {{- include "fedml-server-deployment.labels" . | nindent 4 }}
 spec:

--- a/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/serviceaccount.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-server-deployment/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
-  namespace: {{- with .Values.namespace }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "fedml-server-deployment.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/devops/k8s/fedml-edge-client-server/fedml-server-deployment/values.yaml
+++ b/devops/k8s/fedml-edge-client-server/fedml-server-deployment/values.yaml
@@ -23,7 +23,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ""
+  name: "fedml"
 
 podAnnotations: {}
 


### PR DESCRIPTION
helm install was failing due to lack of namespace name in fedml-edge-server-deployment values.yaml