### PR TITLE
Fix typos in README file of fed_cifar100 dataset

### DIFF
--- a/python/fedml/data/fed_cifar100/README.md
+++ b/python/fedml/data/fed_cifar100/README.md
@@ -22,5 +22,5 @@ Data partition is the same as [TFF](https://www.tensorflow.org/federated/api_doc
 
 | DATASET   | TRAIN CLIENTS | TRAIN EXAMPLES | TEST CLIENTS | TEST EXAMPLES |
 | --------- | ------------- | -------------- | ------------ | ------------- |
-| EMNIST-62 | 500           | 50,000         | 100          | 10,000        |
+| CIFAR100  | 500           | 50,000         | 100          | 10,000        |
 


### PR DESCRIPTION
The dataset name column in the table was `EMNIST-62`, which should be `CIFAR100`