### PR TITLE
Fix Bug: add exception handler when utf-8 cannot decode the output/err

### DIFF
--- a/python/fedml/cli/comm_utils/sys_utils.py
+++ b/python/fedml/cli/comm_utils/sys_utils.py
@@ -568,7 +568,11 @@ def run_cmd(command, show_local_console=False):
     ret_code, out, err = ClientConstants.get_console_pipe_out_err_results(process)
     if ret_code is None or ret_code <= 0:
         if out is not None:
-            out_str = out.decode(encoding="utf-8")
+            try:
+                out_str = out.decode(encoding="utf-8")
+            except:
+                logging.info("utf-8 could not decode the output msg")
+                out_str = ""
             if out_str != "":
                 logging.info("{}".format(out_str))
                 if show_local_console:
@@ -579,7 +583,11 @@ def run_cmd(command, show_local_console=False):
         is_cmd_run_ok = True
     else:
         if err is not None:
-            err_str = err.decode(encoding="utf-8")
+            try:
+                err_str = err.decode(encoding="utf-8")
+            except:
+                logging.info("utf-8 could not decode the err msg")
+                err_str = ""
             if err_str != "":
                 logging.error("{}".format(err_str))
                 if show_local_console:


### PR DESCRIPTION
When user using command line that has default language like Chinese, in this case the utf-8 encoding format might not decode the message.

In this case, if we do not add an exception handler, the program might exit with serious consequence, for example, during the OTA. This exception will terminate the process in the middle of OTA.