### PR TITLE
[CoreEngine] 1. add the cli for showing resource type from the launch platform

### DIFF
--- a/python/fedml/__init__.py
+++ b/python/fedml/__init__.py
@@ -25,15 +25,16 @@ from .core.common.ml_engine_backend import MLEngineBackend
 _global_training_type = None
 _global_comm_backend = None
 
-__version__ = "0.8.8a63"
+__version__ = "0.8.8a64"
 
 
-def init(args=None):
+def init(args=None, check_env=True):
     if args is None:
         args = load_arguments(fedml._global_training_type, fedml._global_comm_backend)
 
     """Initialize FedML Engine."""
-    collect_env(args)
+    if check_env:
+        collect_env(args)
 
     if hasattr(args, "training_type"):
         fedml._global_training_type = args.training_type

--- a/python/fedml/cli/README.md
+++ b/python/fedml/cli/README.md
@@ -166,6 +166,8 @@ fedml_env:
 workspace: hello_world
 
 # Running entry commands which will be executed as the job entry point.
+# If an error occurs, you should exit with a non-zero code, e.g. exit 1.
+# Otherwise, you should exit with a zero code, e.g. exit 0.
 # Support multiple lines, which can not be empty.
 job: | 
     echo "Hello, Here is the launch platform."
@@ -182,6 +184,19 @@ bootstrap: |
 computing:
   minimum_num_gpus: 1             # minimum # of GPUs to provision
   maximum_cost_per_hour: $1.75    # max cost per hour for your job per machine
+  allow_cross_cloud_resources: false # true, false
+  device_type: GPU              # options: GPU, CPU, hybrid
+  resource_type: A100-80G       # e.g., A100-80G, please check the resource type list by "fedml show-resource-type" or visiting URL: https://open.fedml.ai/accelerator_resource_type
+  
+framework_type: fedml         # options: fedml, deepspeed, pytorch, general
+task_type: train              # options: serve, train, dev-environment
+
+# Running entry commands on the server side which will be executed as the job entry point.
+# Support multiple lines, which can not be empty.
+server_job: |
+    echo "Hello, Here is the server job."
+    echo "Current directory is as follows."
+    pwd
 ```
 
 You just need to customize the following config items.

--- a/python/fedml/cli/cli.py
+++ b/python/fedml/cli/cli.py
@@ -54,6 +54,28 @@ def mlops_status():
     )
 
 
+@cli.command("show-resource-type", help="Show resource type at the FedML® Launch platform (open.fedml.ai)")
+@click.help_option("--help", "-h")
+@click.option(
+    "--version",
+    "-v",
+    type=str,
+    default="release",
+    help="show resource type at which version of MLOps platform. It should be dev, test or release",
+)
+def launch_show_resource_type(version):
+    FedMLLaunchManager.get_instance().set_config_version(version)
+    resource_type_list = FedMLLaunchManager.get_instance().show_resource_type()
+    if resource_type_list is not None and len(resource_type_list) > 0:
+        click.echo("All available resource type is as follows.")
+        resource_table = PrettyTable(['Resource Type Name'])
+        for type_item in resource_type_list:
+            resource_table.add_row([type_item])
+        print(resource_table)
+    else:
+        click.echo("No available resource type.")
+
+
 @cli.command("logs", help="Display fedml logs.")
 @click.help_option("--help", "-h")
 @click.option(

--- a/python/fedml/computing/scheduler/comm_utils/sys_utils.py
+++ b/python/fedml/computing/scheduler/comm_utils/sys_utils.py
@@ -781,6 +781,14 @@ def run_subprocess_open(shell_script_list):
     return script_process
 
 
+def decode_our_err_result(out_err):
+    try:
+        result_str = out_err.decode(encoding="utf-8")
+        return result_str
+    except Exception as e:
+        return out_err
+
+
 if __name__ == '__main__':
     fedml_is_latest_version, local_ver, remote_ver = check_fedml_is_latest_version("dev")
     print("FedML is latest version: {}, local version {}, remote version {}".format(

--- a/python/fedml/computing/scheduler/master/docker_login.py
+++ b/python/fedml/computing/scheduler/master/docker_login.py
@@ -3,6 +3,8 @@ import os
 import platform
 
 import click
+from fedml.computing.scheduler.comm_utils import sys_utils
+
 from .server_constants import ServerConstants
 from .server_runner import FedMLServerRunner
 
@@ -85,11 +87,11 @@ def login_with_server_docker_mode(userid, version, docker_rank):
     ret_code, out, err = ServerConstants.get_console_pipe_out_err_results(docker_ps_process)
     is_deployment_ok = False
     if out is not None:
-        out_str = out.decode(encoding="utf-8")
+        out_str = sys_utils.decode_our_err_result(out)
         if str(out_str).find(fedml_docker_name) != -1 and str(out_str).find("Up") != -1:
             is_deployment_ok = True
     if err is not None:
-        err_str = err.decode(encoding="utf-8")
+        err_str = sys_utils.decode_our_err_result(err)
         if str(err_str).find(fedml_docker_name) != -1 and str(err_str).find("Up") != -1:
             is_deployment_ok = True
 
@@ -121,7 +123,7 @@ def logs_with_server_docker_mode(docker_rank):
                                                                            should_capture_stderr=True)
     _, out_id, err_id = ServerConstants.get_console_pipe_out_err_results(docker_name_proc)
     if out_id is not None:
-        out_id_str = out_id.decode(encoding="utf-8")
+        out_id_str = sys_utils.decode_our_err_result(out_id)
         docker_logs_cmd = 'docker logs -f {}'.format(out_id_str)
         os.system(docker_logs_cmd)
 

--- a/python/fedml/computing/scheduler/master/server_constants.py
+++ b/python/fedml/computing/scheduler/master/server_constants.py
@@ -1,4 +1,4 @@
-
+import logging
 import os
 import platform
 import signal
@@ -9,6 +9,8 @@ from urllib.parse import urlparse, unquote
 
 import psutil
 import yaml
+from fedml.computing.scheduler.comm_utils import sys_utils
+
 from ..comm_utils.yaml_utils import load_yaml_config
 
 
@@ -161,6 +163,12 @@ class ServerConstants(object):
         heartbeat_url = "{}/fedmlOpsServer/api/v1/cli/heartBeat".format(
             ServerConstants.get_mlops_url(config_version))
         return heartbeat_url
+
+    @staticmethod
+    def get_resource_url(config_version="release"):
+        resource_url = "{}/fedmlOpsServer/api/v1/cli/resourceType".format(
+            ServerConstants.get_mlops_url(config_version))
+        return resource_url
 
     @staticmethod
     def cleanup_run_process(run_id):
@@ -401,6 +409,29 @@ class ServerConstants(object):
                                               preexec_fn=os.setsid)
 
         return script_process
+
+    @staticmethod
+    def execute_commands_with_live_logs(cmds, join='&&'):
+        error_list = list()
+        with subprocess.Popen(join.join(cmds),
+                              shell=True,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE) as sp:
+            with os.fdopen(sys.stdout.fileno(), 'wb', closefd=False) as stdout:
+                for line in sp.stdout:
+                    line_str = line.decode()
+                    stdout.write(line)
+                    stdout.flush()
+                    logging.info(line_str)
+            with os.fdopen(sys.stderr.fileno(), 'wb', closefd=False) as stderr:
+                for line in sp.stderr:
+                    line_str = line.decode()
+                    stderr.write(line)
+                    stderr.flush()
+                    logging.error(line_str)
+                    error_list.append(line_str)
+            return sp, error_list
+        return None, error_list
 
     @staticmethod
     def get_console_pipe_out_err_results(script_process):

--- a/python/fedml/computing/scheduler/master/server_login.py
+++ b/python/fedml/computing/scheduler/master/server_login.py
@@ -87,7 +87,7 @@ def __login_as_edge_server_and_agent(args, userid, version, api_key="", use_extr
     edge_id = 0
     while register_try_count < 5:
         try:
-            edge_id = runner.bind_account_and_device_id(
+            edge_id, user_name, extra_url = runner.bind_account_and_device_id(
                 service_config["ml_ops_config"]["EDGE_BINDING_URL"], args.account_id, unique_device_id, args.os_name,
                 api_key=api_key, role=role
             )
@@ -183,7 +183,7 @@ def __login_as_cloud_agent(args, userid, version):
         edge_id = 0
     while register_try_count < 5:
         try:
-            edge_id = runner.bind_account_and_device_id(
+            edge_id, user_name, extra_url = runner.bind_account_and_device_id(
                 service_config["ml_ops_config"]["EDGE_BINDING_URL"], args.account_id, unique_device_id, args.os_name
             )
             if edge_id > 0:
@@ -278,7 +278,7 @@ def __login_as_cloud_server(args, userid, version):
     edge_id = 0
     while register_try_count < 5:
         try:
-            edge_id = runner.bind_account_and_device_id(
+            edge_id, user_name, extra_url = runner.bind_account_and_device_id(
                 service_config["ml_ops_config"]["EDGE_BINDING_URL"], args.account_id, unique_device_id, args.os_name
             )
             if edge_id > 0:

--- a/python/fedml/computing/scheduler/master/server_runner.py
+++ b/python/fedml/computing/scheduler/master/server_runner.py
@@ -328,23 +328,26 @@ class FedMLServerRunner:
                                                                  os.path.basename(bootstrap_script_file))
                     bootstrap_scripts = str(bootstrap_scripts).replace('\\', os.sep).replace('/', os.sep)
                     logging.info("Bootstrap scripts are being executed...")
-                    process = ServerConstants.exec_console_with_script(bootstrap_scripts,
-                                                                       should_capture_stdout=True,
-                                                                       should_capture_stderr=True)
-                    ServerConstants.save_bootstrap_process(run_id, process.pid)
+                    shell_cmd_list = list()
+                    shell_cmd_list.append(bootstrap_scripts)
+                    process, error_list = ServerConstants.execute_commands_with_live_logs(shell_cmd_list)
+                    ClientConstants.save_bootstrap_process(run_id, process.pid)
                     ret_code, out, err = ServerConstants.get_console_pipe_out_err_results(process)
                     if ret_code is None or ret_code <= 0:
-                        if out is not None:
-                            out_str = out.decode(encoding="utf-8")
-                            if out_str != "":
-                                logging.info("{}".format(out_str))
+                        if error_list is not None and len(error_list) > 0:
+                            is_bootstrap_run_ok = False
+                        else:
+                            if out is not None:
+                                out_str = sys_utils.decode_our_err_result(out)
+                                if out_str != "":
+                                    logging.info("{}".format(out_str))
 
-                        sys_utils.log_return_info(bootstrap_script_file, 0)
+                            sys_utils.log_return_info(bootstrap_script_file, 0)
 
-                        is_bootstrap_run_ok = True
+                            is_bootstrap_run_ok = True
                     else:
                         if err is not None:
-                            err_str = err.decode(encoding="utf-8")
+                            err_str = sys_utils.decode_our_err_result(err)
                             if err_str != "":
                                 logging.error("{}".format(err_str))
 
@@ -477,7 +480,7 @@ class FedMLServerRunner:
 
         entry_file_full_path = os.path.join(unzip_package_path, "fedml", entry_file)
         conf_file_full_path = os.path.join(unzip_package_path, "fedml", conf_file)
-        process, is_launch_task = self.execute_job_task(entry_file_full_path, conf_file_full_path, run_id)
+        process, is_launch_task, error_list = self.execute_job_task(entry_file_full_path, conf_file_full_path, run_id)
         logging.info("waiting the aggregation process to aggregate models...")
         ServerConstants.save_learning_process(run_id, process.pid)
 
@@ -485,12 +488,14 @@ class FedMLServerRunner:
         is_run_ok = sys_utils.is_runner_finished_normally(process.pid)
         if is_launch_task:
             is_run_ok = True
+        if error_list is not None and len(error_list) > 0:
+            is_run_ok = False
         if ret_code is None or ret_code <= 0:
             self.check_runner_stop_event()
 
             if is_run_ok:
                 if out is not None:
-                    out_str = out.decode(encoding="utf-8")
+                    out_str = sys_utils.decode_our_err_result(out)
                     if out_str != "":
                         logging.info("{}".format(out_str))
 
@@ -516,7 +521,7 @@ class FedMLServerRunner:
             logging.error("failed to run the aggregation process...")
 
             if err is not None:
-                err_str = err.decode(encoding="utf-8")
+                err_str = sys_utils.decode_our_err_result(err)
                 if err_str != "":
                     logging.error("{}".format(err_str))
 
@@ -558,9 +563,11 @@ class FedMLServerRunner:
         run_params = run_config.get("parameters", {})
         job_yaml = run_params.get("job_yaml", {})
         job_yaml_default_none = run_params.get("job_yaml", None)
+        assigned_gpu_ids = run_params.get("gpu_ids", None)
         using_easy_mode = True
         expert_mode = job_yaml.get("expert_mode", None)
         framework_type = job_yaml.get("framework_type", None)
+        error_list = list()
         if expert_mode is None:
             executable_interpreter = ClientConstants.CLIENT_SHELL_PS \
                 if platform.system() == ClientConstants.PLATFORM_WINDOWS else ClientConstants.CLIENT_SHELL_BASH
@@ -600,10 +607,22 @@ class FedMLServerRunner:
                                                              running_json=self.start_request_json)
 
             shell_cmd_list = list()
-            shell_cmd_list.append(executable_interpreter)
             if using_easy_mode:
-                shell_cmd_list.append(entry_file_full_path)
+                entry_commands = list()
+                with open(entry_file_full_path, 'r') as entry_file_handle:
+                    entry_commands.extend(entry_file_handle.readlines())
+                    entry_file_handle.close()
+
+                entry_commands.insert(0, f"export FEDML_CURRENT_EDGE_ID={self.edge_id}\n")
+                entry_commands.insert(0, f"export FEDML_CURRENT_JOB_ID={self.run_id}\n")
+                if assigned_gpu_ids is not None and assigned_gpu_ids != "":
+                    entry_commands.insert(0, f"export CUDA_VISIBLE_DEVICES={assigned_gpu_ids}\n")
+                with open(entry_file_full_path, 'w') as entry_file_handle:
+                    entry_file_handle.writelines(entry_commands)
+                    entry_file_handle.close()
+                shell_cmd_list.append(f"{executable_interpreter} {entry_file_full_path}")
             else:
+                shell_cmd_list.append(executable_interpreter)
                 if executable_file != "":
                     shell_cmd_list.append(entry_file_full_path)
                 if executable_conf_file != "" and executable_conf_option != "":
@@ -614,13 +633,9 @@ class FedMLServerRunner:
                 shell_cmd_list.append(f"--run_device_id {self.edge_id}")
                 shell_cmd_list.append("--using_mlops True")
             logging.info(f"Run the server job with job id {self.run_id}, device id {self.edge_id}.")
-            process = ServerConstants.exec_console_with_shell_script_list(
-                shell_cmd_list,
-                should_capture_stdout=True,
-                should_capture_stderr=True
-            )
+            process, error_list = ClientConstants.execute_commands_with_live_logs(shell_cmd_list)
             is_launch_task = True
-        return process, is_launch_task
+        return process, is_launch_task, error_list
 
     def process_job_status(self, run_id):
         all_edges_is_finished = True
@@ -1574,12 +1589,25 @@ class FedMLServerRunner:
                 )
         else:
             response = requests.post(url, json=json_params, headers={"Connection": "close"})
-        status_code = response.json().get("code")
-        if status_code == "SUCCESS":
-            edge_id = response.json().get("data").get("id")
+        if response.status_code != 200:
+            print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                  f"response.content: {response.content}")
+            pass
         else:
-            return 0
-        return edge_id
+            # print("url = {}, response = {}".format(url, response))
+            status_code = response.json().get("code")
+            if status_code == "SUCCESS":
+                edge_id = response.json().get("data").get("id")
+                user_name = response.json().get("data").get("userName", None)
+                extra_url = response.json().get("data").get("url", None)
+                if edge_id is None or edge_id <= 0:
+                    print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                          f"response.content: {response.content}")
+            else:
+                print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                      f"response.content: {response.content}")
+                return 0, None, None
+        return edge_id, user_name, extra_url
 
     def fetch_configs(self):
         return MLOpsConfigs.get_instance(self.args).fetch_all_configs()

--- a/python/fedml/computing/scheduler/master/templates/fedml-server-deployment.yaml
+++ b/python/fedml/computing/scheduler/master/templates/fedml-server-deployment.yaml
@@ -13,8 +13,6 @@ spec:
       labels:
         app: fedml-aggregator
     spec:
-      imagePullSecrets:
-        - name: open-ecr-secret
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/python/fedml/computing/scheduler/model_scheduler/device_client_login.py
+++ b/python/fedml/computing/scheduler/model_scheduler/device_client_login.py
@@ -106,7 +106,7 @@ def __login_as_client(args, userid, version):
     edge_id = 0
     while register_try_count < 5:
         try:
-            edge_id = runner.bind_account_and_device_id(
+            edge_id, user_name, extra_url = runner.bind_account_and_device_id(
                 service_config["ml_ops_config"]["EDGE_BINDING_URL"], args.account_id, unique_device_id, args.os_name
             )
             if edge_id > 0:

--- a/python/fedml/computing/scheduler/model_scheduler/device_client_runner.py
+++ b/python/fedml/computing/scheduler/model_scheduler/device_client_runner.py
@@ -870,12 +870,25 @@ class FedMLClientRunner:
                 )
         else:
             response = requests.post(url, json=json_params, headers={"Connection": "close"})
-        status_code = response.json().get("code")
-        if status_code == "SUCCESS":
-            edge_id = response.json().get("data").get("id")
+        if response.status_code != 200:
+            print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                  f"response.content: {response.content}")
+            pass
         else:
-            return 0
-        return edge_id
+            # print("url = {}, response = {}".format(url, response))
+            status_code = response.json().get("code")
+            if status_code == "SUCCESS":
+                edge_id = response.json().get("data").get("id")
+                user_name = response.json().get("data").get("userName", None)
+                extra_url = response.json().get("data").get("url", None)
+                if edge_id is None or edge_id <= 0:
+                    print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                          f"response.content: {response.content}")
+            else:
+                print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                      f"response.content: {response.content}")
+                return 0, None, None
+        return edge_id, user_name, extra_url
 
     def fetch_configs(self):
         return MLOpsConfigs.get_instance(self.args).fetch_all_configs()

--- a/python/fedml/computing/scheduler/model_scheduler/device_model_deployment.py
+++ b/python/fedml/computing/scheduler/model_scheduler/device_model_deployment.py
@@ -14,6 +14,8 @@ import tritonclient.http as http_client
 
 import collections.abc
 
+from fedml.computing.scheduler.comm_utils import sys_utils
+
 for type_name in collections.abc.__all__:
     setattr(collections, type_name, getattr(collections.abc, type_name))
 
@@ -91,7 +93,7 @@ def start_deployment(end_point_id, end_point_name, model_id, model_version,
                                                                        should_capture_stderr=True)
             ret_code, out, err = ClientConstants.get_console_pipe_out_err_results(running_process)
             if out is not None:
-                out_str = out.decode(encoding="utf-8")
+                out_str = sys_utils.decode_our_err_result(out)
                 if str(out_str) != "":
                     triton_server_is_running = True
 
@@ -454,7 +456,7 @@ def should_exit_logs(end_point_id, model_id, cmd_type, model_name, inference_eng
                                                                      should_capture_stderr=True)
         ret_code, out, err = ClientConstants.get_console_pipe_out_err_results(docker_ps_process)
         if out is not None:
-            out_str = out.decode(encoding="utf-8")
+            out_str = sys_utils.decode_our_err_result(out)
             if str(out_str).find(convert_model_container_name) == -1:
                 return True
             else:
@@ -494,13 +496,13 @@ def log_deployment_result(end_point_id, model_id, cmd_container_name, cmd_type,
                                                                     should_capture_stderr=True)
             ret_code, out, err = ClientConstants.get_console_pipe_out_err_results(logs_process)
             if out is not None:
-                out_str = out.decode(encoding="utf-8")
+                out_str = sys_utils.decode_our_err_result(out)
                 added_logs = str(out_str).replace(last_out_logs, "")
                 if len(added_logs) > 0:
                     logging.info("{}".format(added_logs))
                 last_out_logs = out_str
             elif err is not None:
-                err_str = err.decode(encoding="utf-8")
+                err_str = sys_utils.decode_our_err_result(err)
                 added_logs = str(err_str).replace(last_err_logs, "")
                 if len(added_logs) > 0:
                     logging.info("{}".format(added_logs))

--- a/python/fedml/computing/scheduler/model_scheduler/device_server_login.py
+++ b/python/fedml/computing/scheduler/model_scheduler/device_server_login.py
@@ -96,7 +96,7 @@ def __login_as_edge_server_and_agent(args, userid, version):
     edge_id = 0
     while register_try_count < 5:
         try:
-            edge_id = runner.bind_account_and_device_id(
+            edge_id, user_name, extra_url = runner.bind_account_and_device_id(
                 service_config["ml_ops_config"]["EDGE_BINDING_URL"], args.account_id, unique_device_id, args.os_name
             )
             if edge_id > 0:
@@ -195,7 +195,7 @@ def __login_as_cloud_agent(args, userid, version):
         edge_id = 0
     while register_try_count < 5:
         try:
-            edge_id = runner.bind_account_and_device_id(
+            edge_id, user_name, extra_url = runner.bind_account_and_device_id(
                 service_config["ml_ops_config"]["EDGE_BINDING_URL"], args.account_id, unique_device_id, args.os_name
             )
             if edge_id > 0:
@@ -294,7 +294,7 @@ def __login_as_cloud_server(args, userid, version):
     edge_id = 0
     while register_try_count < 5:
         try:
-            edge_id = runner.bind_account_and_device_id(
+            edge_id, user_name, extra_url = runner.bind_account_and_device_id(
                 service_config["ml_ops_config"]["EDGE_BINDING_URL"], args.account_id, unique_device_id, args.os_name
             )
             if edge_id > 0:

--- a/python/fedml/computing/scheduler/model_scheduler/device_server_runner.py
+++ b/python/fedml/computing/scheduler/model_scheduler/device_server_runner.py
@@ -1315,12 +1315,25 @@ class FedMLServerRunner:
                 )
         else:
             response = requests.post(url, json=json_params, headers={"Connection": "close"})
-        status_code = response.json().get("code")
-        if status_code == "SUCCESS":
-            edge_id = response.json().get("data").get("id")
+        if response.status_code != 200:
+            print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                  f"response.content: {response.content}")
+            pass
         else:
-            return 0
-        return edge_id
+            # print("url = {}, response = {}".format(url, response))
+            status_code = response.json().get("code")
+            if status_code == "SUCCESS":
+                edge_id = response.json().get("data").get("id")
+                user_name = response.json().get("data").get("userName", None)
+                extra_url = response.json().get("data").get("url", None)
+                if edge_id is None or edge_id <= 0:
+                    print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                          f"response.content: {response.content}")
+            else:
+                print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                      f"response.content: {response.content}")
+                return 0, None, None
+        return edge_id, user_name, extra_url
 
     def fetch_configs(self):
         return MLOpsConfigs.get_instance(self.args).fetch_all_configs()

--- a/python/fedml/computing/scheduler/model_scheduler/docker_client_login.py
+++ b/python/fedml/computing/scheduler/model_scheduler/docker_client_login.py
@@ -3,6 +3,8 @@ import os
 import platform
 
 import click
+from fedml.computing.scheduler.comm_utils import sys_utils
+
 from .device_client_constants import ClientConstants
 from .device_client_runner import FedMLClientRunner
 
@@ -83,11 +85,11 @@ def login_with_docker_mode(userid, version, docker_rank):
     ret_code, out, err = ClientConstants.get_console_pipe_out_err_results(docker_ps_process)
     is_deployment_ok = False
     if out is not None:
-        out_str = out.decode(encoding="utf-8")
+        out_str = sys_utils.decode_our_err_result(out)
         if str(out_str).find(fedml_docker_name) != -1 and str(out_str).find("Up") != -1:
             is_deployment_ok = True
     if err is not None:
-        err_str = err.decode(encoding="utf-8")
+        err_str = sys_utils.decode_our_err_result(err)
         if str(err_str).find(fedml_docker_name) != -1 and str(err_str).find("Up") != -1:
             is_deployment_ok = True
 
@@ -119,7 +121,7 @@ def logs_with_docker_mode(docker_rank):
                                                                            should_capture_stdout_err=True)
     _, out_id, err_id = ClientConstants.get_console_pipe_out_err_results(docker_name_proc)
     if out_id is not None:
-        out_id_str = out_id.decode(encoding="utf-8")
+        out_id_str = sys_utils.decode_our_err_result(out_id)
         docker_logs_cmd = 'docker logs -f {}'.format(out_id_str)
         os.system(docker_logs_cmd)
 

--- a/python/fedml/computing/scheduler/model_scheduler/docker_server_login.py
+++ b/python/fedml/computing/scheduler/model_scheduler/docker_server_login.py
@@ -3,6 +3,8 @@ import os
 import platform
 
 import click
+from fedml.computing.scheduler.comm_utils import sys_utils
+
 from .device_server_constants import ServerConstants
 from .device_server_runner import FedMLServerRunner
 
@@ -83,11 +85,11 @@ def login_with_server_docker_mode(userid, version, docker_rank):
     ret_code, out, err = ServerConstants.get_console_pipe_out_err_results(docker_ps_process)
     is_deployment_ok = False
     if out is not None:
-        out_str = out.decode(encoding="utf-8")
+        out_str = sys_utils.decode_our_err_result(out)
         if str(out_str).find(fedml_docker_name) != -1 and str(out_str).find("Up") != -1:
             is_deployment_ok = True
     if err is not None:
-        err_str = err.decode(encoding="utf-8")
+        err_str = sys_utils.decode_our_err_result(err)
         if str(err_str).find(fedml_docker_name) != -1 and str(err_str).find("Up") != -1:
             is_deployment_ok = True
 
@@ -118,7 +120,7 @@ def logs_with_server_docker_mode(docker_rank):
                                                                            should_capture_stdout_err=True)
     _, out_id, err_id = ServerConstants.get_console_pipe_out_err_results(docker_name_proc)
     if out_id is not None:
-        out_id_str = out_id.decode(encoding="utf-8")
+        out_id_str = sys_utils.decode_our_err_result(out_id)
         docker_logs_cmd = 'docker logs -f {}'.format(out_id_str)
         os.system(docker_logs_cmd)
 

--- a/python/fedml/computing/scheduler/scheduler_entry/README.md
+++ b/python/fedml/computing/scheduler/scheduler_entry/README.md
@@ -22,6 +22,8 @@ fedml_env:
 workspace: hello_world
 
 # Running entry commands which will be executed as the job entry point.
+# If an error occurs, you should exit with a non-zero code, e.g. exit 1.
+# Otherwise, you should exit with a zero code, e.g. exit 0.
 # Support multiple lines, which can not be empty.
 job: | 
     echo "Hello, Here is the launch platform."
@@ -40,6 +42,7 @@ computing:
   maximum_cost_per_hour: $1.75    # max cost per hour for your job per machine
   allow_cross_cloud_resources: false # true, false
   device_type: GPU              # options: GPU, CPU, hybrid
+  resource_type: A100-80G       # e.g., A100-80G, please check the resource type list by "fedml show-resource-type" or visiting URL: https://open.fedml.ai/accelerator_resource_type
   
 framework_type: fedml         # options: fedml, deepspeed, pytorch, general
 task_type: train              # options: serve, train, dev-environment

--- a/python/fedml/computing/scheduler/scheduler_entry/call_gpu.yaml
+++ b/python/fedml/computing/scheduler/scheduler_entry/call_gpu.yaml
@@ -4,19 +4,25 @@
 workspace: hello_world
 
 # Running entry commands which will be executed as the job entry point.
+# If an error occurs, you should exit with a non-zero code, e.g. exit 1.
+# Otherwise, you should exit with a zero code, e.g. exit 0.
 # Support multiple lines, which can not be empty.
-job: | 
+job: |
+    echo "current job id: $FEDML_CURRENT_JOB_ID"
+    echo "current edge id: $FEDML_CURRENT_EDGE_ID"
     echo "Hello, Here is the launch platform."
     echo "Current directory is as follows."
     pwd
-    # sleep 15
-    echo "Current GPU information is as follows."
-    nvidia-smi # Print GPU information
-    gpustat
-    echo "Download the file from http://212.183.159.230/200MB.zip ..."
-    wget http://212.183.159.230/200MB.zip
-    rm ./200MB.zip*
-    echo "The downloading task has finished."
+    #python3 hello_world.py
+    #sleep 20
+    #exit 1
+    #echo "Current GPU information is as follows."
+    #nvidia-smi # Print GPU information
+    #gpustat
+    #echo "Download the file from http://212.183.159.230/200MB.zip ..."
+    #wget http://212.183.159.230/200MB.zip
+    #rm ./200MB.zip*
+    #echo "The downloading task has finished."
     # echo "Training the vision transformer model using PyTorch..."
     # python vision_transformer.py --epochs 1
 
@@ -33,11 +39,12 @@ bootstrap: |
   # pip install -r requirements.txt
   echo "Bootstrap finished."
 
-# framework_type: fedml         # options: fedml, deepspeed, pytorch, general
+#framework_type: fedml         # options: fedml, deepspeed, pytorch, general
 #task_type: train              # options: serve, train, dev-environment
 
 computing:
   minimum_num_gpus: 1           # minimum # of GPUs to provision
-  maximum_cost_per_hour: $3000   # max cost per hour for your job per machine
+  maximum_cost_per_hour: $3000   # max cost per hour for your job per gpu card
   #allow_cross_cloud_resources: true # true, false
   #device_type: CPU              # options: GPU, CPU, hybrid
+  #resource_type: A100-80G       # e.g., A100-80G, please check the resource type list by "fedml show-resource-type" or visiting URL: https://open.fedml.ai/accelerator_resource_type

--- a/python/fedml/computing/scheduler/scheduler_entry/hello_world/hello_world.py
+++ b/python/fedml/computing/scheduler/scheduler_entry/hello_world/hello_world.py
@@ -1,3 +1,10 @@
+import fedml
 
 if __name__ == "__main__":
     print("Hi everyone, I am an launch job.")
+    artifact = fedml.mlops.Artifact(name="general-file", type=fedml.mlops.ARTIFACT_TYPE_NAME_GENERAL)
+    artifact.add_file("./requirements.txt")
+    artifact.add_dir("./config")
+    fedml.mlops.log_artifact(artifact, version="dev")
+
+    fedml.mlops.log_model("cv-model", "./requirements.txt", version="dev")

--- a/python/fedml/computing/scheduler/scheduler_entry/launch_manager.py
+++ b/python/fedml/computing/scheduler/scheduler_entry/launch_manager.py
@@ -436,6 +436,10 @@ class FedMLLaunchManager(Singleton):
         except Exception as e:
             return ""
 
+    def show_resource_type(self):
+        FedMLJobManager.get_instance().set_config_version(self.config_version)
+        return FedMLJobManager.get_instance().show_resource_type()
+
 
 '''
 For the Job yaml file, please review the call_gpu.yaml :

--- a/python/fedml/computing/scheduler/slave/client_runner.py
+++ b/python/fedml/computing/scheduler/slave/client_runner.py
@@ -313,22 +313,26 @@ class FedMLClientRunner:
                                                                  os.path.basename(bootstrap_script_file))
                     bootstrap_scripts = str(bootstrap_scripts).replace('\\', os.sep).replace('/', os.sep)
                     logging.info("Bootstrap scripts are being executed...")
-                    process = ClientConstants.exec_console_with_script(bootstrap_scripts, should_capture_stdout=True,
-                                                                       should_capture_stderr=True)
+                    shell_cmd_list = list()
+                    shell_cmd_list.append(bootstrap_scripts)
+                    process, error_list = ClientConstants.execute_commands_with_live_logs(shell_cmd_list)
                     ClientConstants.save_bootstrap_process(run_id, process.pid)
                     ret_code, out, err = ClientConstants.get_console_pipe_out_err_results(process)
                     if ret_code is None or ret_code <= 0:
-                        if out is not None:
-                            out_str = out.decode(encoding="utf-8")
-                            if out_str != "":
-                                logging.info("{}".format(out_str))
+                        if error_list is not None and len(error_list) > 0:
+                            is_bootstrap_run_ok = False
+                        else:
+                            if out is not None:
+                                out_str = sys_utils.decode_our_err_result(out)
+                                if out_str != "":
+                                    logging.info("{}".format(out_str))
 
-                        sys_utils.log_return_info(bootstrap_script_file, 0)
+                            sys_utils.log_return_info(bootstrap_script_file, 0)
 
-                        is_bootstrap_run_ok = True
+                            is_bootstrap_run_ok = True
                     else:
                         if err is not None:
-                            err_str = err.decode(encoding="utf-8")
+                            err_str = sys_utils.decode_our_err_result(err)
                             if err_str != "":
                                 logging.error("{}".format(err_str))
 
@@ -442,8 +446,8 @@ class FedMLClientRunner:
         entry_file_full_path = os.path.join(unzip_package_path, "fedml", entry_file)
         conf_file_full_path = os.path.join(unzip_package_path, "fedml", conf_file)
         computing_started_time = MLOpsUtils.get_ntp_time()
-        process, is_launch_task = self.execute_job_task(entry_file_full_path, conf_file_full_path, dynamic_args_config)
         logging.info("waiting the learning process to train models...")
+        process, is_launch_task, error_list = self.execute_job_task(entry_file_full_path, conf_file_full_path, dynamic_args_config)
         ClientConstants.save_learning_process(run_id, process.pid)
 
         ret_code, out, err = ClientConstants.get_console_pipe_out_err_results(process)
@@ -454,12 +458,14 @@ class FedMLClientRunner:
         is_run_ok = sys_utils.is_runner_finished_normally(process.pid)
         if is_launch_task:
             is_run_ok = True
+        if error_list is not None and len(error_list) > 0:
+            is_run_ok = False
         if ret_code is None or ret_code <= 0:
             self.check_runner_stop_event()
 
             if is_run_ok:
                 if out is not None:
-                    out_str = out.decode(encoding="utf-8")
+                    out_str = sys_utils.decode_our_err_result(out)
                     if out_str != "":
                         logging.info("{}".format(out_str))
 
@@ -486,7 +492,7 @@ class FedMLClientRunner:
             logging.error("failed to run the learning process...")
 
             if err is not None:
-                err_str = err.decode(encoding="utf-8")
+                err_str = sys_utils.decode_our_err_result(err)
                 if err_str != "":
                     logging.error("{}".format(err_str))
 
@@ -507,8 +513,10 @@ class FedMLClientRunner:
         run_params = run_config.get("parameters", {})
         job_yaml = run_params.get("job_yaml", {})
         job_yaml_default_none = run_params.get("job_yaml", None)
+        assigned_gpu_ids = run_params.get("gpu_ids", None)
         using_easy_mode = True
         expert_mode = job_yaml.get("expert_mode", None)
+        error_list = list()
         if expert_mode is None:
             executable_interpreter = ClientConstants.CLIENT_SHELL_PS \
                 if platform.system() == ClientConstants.PLATFORM_WINDOWS else ClientConstants.CLIENT_SHELL_BASH
@@ -548,10 +556,22 @@ class FedMLClientRunner:
                                                              ClientConstants.MSG_MLOPS_SERVER_DEVICE_STATUS_RUNNING,
                                                              in_run_id=self.run_id)
             shell_cmd_list = list()
-            shell_cmd_list.append(executable_interpreter)
             if using_easy_mode:
-                shell_cmd_list.append(entry_file_full_path)
+                entry_commands = list()
+                with open(entry_file_full_path, 'r') as entry_file_handle:
+                    entry_commands.extend(entry_file_handle.readlines())
+                    entry_file_handle.close()
+
+                entry_commands.insert(0, f"export FEDML_CURRENT_EDGE_ID={self.edge_id}\n")
+                entry_commands.insert(0, f"export FEDML_CURRENT_JOB_ID={self.run_id}\n")
+                if assigned_gpu_ids is not None and assigned_gpu_ids != "":
+                    entry_commands.insert(0, f"export CUDA_VISIBLE_DEVICES={assigned_gpu_ids}\n")
+                with open(entry_file_full_path, 'w') as entry_file_handle:
+                    entry_file_handle.writelines(entry_commands)
+                    entry_file_handle.close()
+                shell_cmd_list.append(f"{executable_interpreter} {entry_file_full_path}")
             else:
+                shell_cmd_list.append(executable_interpreter)
                 if executable_file != "":
                     shell_cmd_list.append(entry_file_full_path)
                 if executable_conf_file != "" and executable_conf_option != "":
@@ -562,13 +582,9 @@ class FedMLClientRunner:
                 shell_cmd_list.append(f"--run_device_id {self.edge_id}")
                 shell_cmd_list.append("--using_mlops True")
             logging.info(f"Run the client job with job id {self.run_id}, device id {self.edge_id}.")
-            process = ClientConstants.exec_console_with_shell_script_list(
-                shell_cmd_list,
-                should_capture_stdout=True,
-                should_capture_stderr=True
-            )
+            process, error_list = ClientConstants.execute_commands_with_live_logs(shell_cmd_list)
             is_launch_task = True
-        return process, is_launch_task
+        return process, is_launch_task, error_list
 
     def reset_devices_status(self, edge_id, status):
         self.mlops_metrics.run_id = self.run_id
@@ -1102,14 +1118,24 @@ class FedMLClientRunner:
                 )
         else:
             response = requests.post(url, json=json_params, headers={"Connection": "close"})
-        # print("url = {}, response = {}".format(url, response))
-        status_code = response.json().get("code")
-        if status_code == "SUCCESS":
-            edge_id = response.json().get("data").get("id")
-            user_name = response.json().get("data").get("userName", None)
-            extra_url = response.json().get("data").get("url", None)
+        if response.status_code != 200:
+            print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                  f"response.content: {response.content}")
+            pass
         else:
-            return 0, None, None
+            # print("url = {}, response = {}".format(url, response))
+            status_code = response.json().get("code")
+            if status_code == "SUCCESS":
+                edge_id = response.json().get("data").get("id")
+                user_name = response.json().get("data").get("userName", None)
+                extra_url = response.json().get("data").get("url", None)
+                if edge_id is None or edge_id <= 0:
+                    print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                          f"response.content: {response.content}")
+            else:
+                print(f"Binding to MLOps with response.status_code = {response.status_code}, "
+                      f"response.content: {response.content}")
+                return 0, None, None
         return edge_id, user_name, extra_url
 
     def fetch_configs(self):

--- a/python/fedml/computing/scheduler/slave/docker_login.py
+++ b/python/fedml/computing/scheduler/slave/docker_login.py
@@ -3,6 +3,8 @@ import os
 import platform
 
 import click
+from fedml.computing.scheduler.comm_utils import sys_utils
+
 from .client_constants import ClientConstants
 from .client_runner import FedMLClientRunner
 
@@ -85,11 +87,11 @@ def login_with_docker_mode(userid, version, docker_rank):
     ret_code, out, err = ClientConstants.get_console_pipe_out_err_results(docker_ps_process)
     is_deployment_ok = False
     if out is not None:
-        out_str = out.decode(encoding="utf-8")
+        out_str = sys_utils.decode_our_err_result(out)
         if str(out_str).find(fedml_docker_name) != -1 and str(out_str).find("Up") != -1:
             is_deployment_ok = True
     if err is not None:
-        err_str = err.decode(encoding="utf-8")
+        err_str = sys_utils.decode_our_err_result(err)
         if str(err_str).find(fedml_docker_name) != -1 and str(err_str).find("Up") != -1:
             is_deployment_ok = True
 
@@ -122,7 +124,7 @@ def logs_with_docker_mode(docker_rank):
                                                                            should_capture_stderr=True)
     _, out_id, err_id = ClientConstants.get_console_pipe_out_err_results(docker_name_proc)
     if out_id is not None:
-        out_id_str = out_id.decode(encoding="utf-8")
+        out_id_str = sys_utils.decode_our_err_result(out_id)
         docker_logs_cmd = 'docker logs -f {}'.format(out_id_str)
         os.system(docker_logs_cmd)
 

--- a/python/fedml/core/mlops/mlops_metrics.py
+++ b/python/fedml/core/mlops/mlops_metrics.py
@@ -510,6 +510,25 @@ class MLOpsMetrics(object):
 
         return False
 
+    def report_artifact_info(self, job_id, edge_id, artifact_name, artifact_type,
+                             artifact_local_path, artifact_url,
+                             artifact_ext_info, artifact_desc,
+                             timestamp):
+        topic_name = "launch_device/mlops/artifacts"
+        artifact_info_json = {
+            "job_id": job_id,
+            "edge_id": edge_id,
+            "artifact_name": artifact_name,
+            "artifact_local_path": artifact_local_path,
+            "artifact_url": artifact_url,
+            "artifact_type": artifact_type,
+            "artifact_desc": artifact_desc,
+            "artifact_ext_info": artifact_ext_info,
+            "timestamp": timestamp
+        }
+        message_json = json.dumps(artifact_info_json)
+        self.messenger.send_message_json(topic_name, message_json)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/python/fedml/mlops/__init__.py
+++ b/python/fedml/mlops/__init__.py
@@ -1,5 +1,8 @@
 import logging
+import os
 import traceback
+
+import fedml
 
 from ..core import mlops
 
@@ -103,6 +106,56 @@ def log_print_init():
 
 def log_print_cleanup():
     mlops.log_print_end()
+
+
+
+ARTIFACT_TYPE_GENERAL = 1  # general file
+ARTIFACT_TYPE_MODEL = 2  # model file
+ARTIFACT_TYPE_DATASET = 3  # dataset file
+ARTIFACT_TYPE_SOURCE = 4  # source code
+ARTIFACT_TYPE_LOG = 5  # log file
+
+ARTIFACT_TYPE_NAME_GENERAL = "general"  # general file
+ARTIFACT_TYPE_NAME_MODEL = "model"  # model file
+ARTIFACT_TYPE_NAME_DATASET = "dataset"  # dataset file
+ARTIFACT_TYPE_NAME_SOURCE = "source code"  # source code
+ARTIFACT_TYPE_NAME__LOG = "log"  # log file
+
+artifact_type_map = {ARTIFACT_TYPE_NAME_GENERAL: ARTIFACT_TYPE_GENERAL,
+                     ARTIFACT_TYPE_NAME_MODEL: ARTIFACT_TYPE_MODEL,
+                     ARTIFACT_TYPE_NAME_DATASET: ARTIFACT_TYPE_DATASET,
+                     ARTIFACT_TYPE_NAME_SOURCE: ARTIFACT_TYPE_SOURCE,
+                     ARTIFACT_TYPE_NAME__LOG: ARTIFACT_TYPE_LOG}
+
+
+class Artifact:
+    def __init__(self, name="", type=ARTIFACT_TYPE_NAME_GENERAL):
+        self.artifact_name = name
+        self.artifact_type_name = type
+        self.artifact_type = artifact_type_map[type]
+        self.artifact_desc = ""
+        self.artifact_files = list()
+        self.artifact_dirs = list()
+        self.ext_info = dict()
+
+    def add_file(self, file_path):
+        if os.path.exists(file_path):
+            self.artifact_files.append(file_path)
+
+    def add_dir(self, dir_path):
+        if os.path.exists(dir_path):
+            self.artifact_dirs.append(dir_path)
+
+    def set_ext_info(self, ext_info_dict):
+        self.ext_info = ext_info_dict
+
+
+def log_artifact(artifact: Artifact, version=None):
+    mlops.log_artifact(artifact, version=version)
+
+
+def log_model(model_name, model_file_path, version=None):
+    mlops.log_model(model_name, model_file_path, version=version)
 
 
 from ..computing.scheduler.slave.client_constants import ClientConstants

--- a/python/fedml/serving/fedml_predictor.py
+++ b/python/fedml/serving/fedml_predictor.py
@@ -55,7 +55,7 @@ def build_dynamic_args():
                 
                 if ret_code is None or ret_code <= 0:
                     if out is not None:
-                        out_str = out.decode(encoding="utf-8")
+                        out_str = sys_utils.decode_our_err_result(out)
                         if out_str != "":
                             logging.info("{}".format(out_str))
 
@@ -64,7 +64,7 @@ def build_dynamic_args():
                     is_bootstrap_run_ok = True
                 else:
                     if err is not None:
-                        err_str = err.decode(encoding="utf-8")
+                        err_str = sys_utils.decode_our_err_result(err)
                         if err_str != "":
                             logging.error("{}".format(err_str))
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,7 +95,7 @@ requirements_extra_crypto = [
 
 setup(
     name="fedml",
-    version="0.8.8a63",
+    version="0.8.8a64",
     author="FedML Team",
     author_email="ch@fedml.ai",
     description="A research and production integrated edge-cloud library for "


### PR DESCRIPTION
2. add the resource_type in the README.md
3. unify the decoding api for stdout and stderr.
4. show live logs when running the job.
5. show live logs when running the bootstrap script.
6. unify the binding api for client and server and print the error message when errors occur.
7. pull the public server image by anonymous mode.
8. add APIs for uploading artifacts to log to MLOps.