### PR TITLE
Downgrading PyYaml to `5.3.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.21
-PyYAML~=5.4.1
+PyYAML~=5.3.1
 h5py~=3.7.0
 tqdm~=4.64.0
 wget~=3.2


### PR DESCRIPTION
```
Collecting numpy>=1.21
  Using cached numpy-1.25.2-cp311-cp311-macosx_10_9_x86_64.whl (20.8 MB)
Collecting PyYAML~=5.4.1
  Using cached PyYAML-5.4.1.tar.gz (175 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [68 lines of output]
      /private/var/folders/sv/pxkddnl523j8qsg_2hk02kzh0000gn/T/pip-build-env-volvwp2_/overlay/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
      !!

              ********************************************************************************
              The license_file parameter is deprecated, use license_files instead.

              By 2023-Oct-30, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
              ********************************************************************************

      !!
```

Seems to be a bug in PyYaml `5.4.1`: https://stackoverflow.com/questions/76707475/issue-importing-pyyaml-cltk

