### PR TITLE
Cleanup launch

### DIFF
--- a/python/fedml/cli/modules/job.py
+++ b/python/fedml/cli/modules/job.py
@@ -83,7 +83,7 @@ def stop_job(platform, job_id, api_key, version):
 def list_jobs(platform, job_name, job_id, api_key, version):
     fedml.set_env_version(version)
     job_list_obj = fedml.api.job_list(api_key=api_key, job_name=job_name, job_id=job_id,
-                                       platform=platform)
+                                      platform=platform)
 
     _print_job_table(job_list_obj)
 
@@ -216,6 +216,14 @@ def logs(platform, job_id, api_key, version, page_num, page_size, need_all_logs)
         click.echo("\nAll logs is as follows.")
         for log_line in log_list:
             click.echo(log_line.rstrip('\n'))
+
+
+@fedml_jobs.command("queue", help="View the job queue at the FedML® Launch platform (open.fedml.ai)", )
+@click.help_option("--help", "-h")
+@click.argument("group_id", nargs=-1)
+def fedml_launch_queue(group_id):
+    click.echo("this CLI is not implemented yet")
+    return
 
 
 def _print_job_table(job_list_obj):

--- a/python/fedml/cli/modules/launch.py
+++ b/python/fedml/cli/modules/launch.py
@@ -14,7 +14,7 @@ def fedml_launch():
 
 @fedml_launch.command(
     "default", help="Launch job at the FedML® Launch platform (open.fedml.ai)",
-    context_settings={"ignore_unknown_options": True}
+    context_settings={"ignore_unknown_options": True}, hidden=True
 )
 @click.help_option("--help", "-h")
 @click.option(
@@ -49,39 +49,3 @@ def fedml_launch_default(yaml_file, api_key, group, cluster, version):
     """
     fedml.set_env_version(version)
     fedml.api.launch_job(yaml_file[0], cluster=cluster, api_key=api_key)
-
-
-@fedml_launch.command("cancel", help="Cancel job at the FedML® Launch platform (open.fedml.ai)", )
-@click.help_option("--help", "-h")
-@click.argument("job_id", nargs=-1)
-@click.option(
-    "--platform",
-    "-pf",
-    type=str,
-    default="falcon",
-    help="The platform name at the MLOps platform (options: octopus, parrot, spider, beehive, falcon, launch, "
-         "default is falcon).",
-)
-@click.option(
-    "--api_key", "-k", type=str, help="user api key.",
-)
-@click.option(
-    "--version",
-    "-v",
-    type=str,
-    default="release",
-    help="stop a job at which version of FedML® Launch platform. It should be dev, test or release",
-)
-def fedml_launch_cancel(job_id, platform, api_key, version):
-    fedml.set_env_version(version)
-    if len(job_id) == 0:
-        print("no job is running.")
-    else:
-        fedml.api.job_stop(job_id[0], platform, api_key)
-
-
-@fedml_launch.command("queue", help="View the job queue at the FedML® Launch platform (open.fedml.ai)", )
-@click.help_option("--help", "-h")
-@click.argument("group_id", nargs=-1)
-def fedml_launch_queue(group_id):
-    print("this CLI is not implemented yet")


### PR DESCRIPTION
### Changes:

- Hide `default` command
- Deprecated `cancel` as it's duplicative to `fedml job stop`
- Moved `queue` from `launch` to `job` group.

```
❯ fedml launch -h
Usage: fedml launch [OPTIONS] COMMAND [ARGS]...

  Manage resources on the FedML® Launch platform (open.fedml.ai).

Options:
  -h, --help  Show this message and exit.
```


```
❯ fedml job -h   
Usage: fedml job [OPTIONS] COMMAND [ARGS]...

  Manage jobs on the MLOps platform.

Options:
  -h, --help  Show this message and exit.

Commands:
  list    List jobs from the MLOps platform.
  logs    Get logs of job from the MLOps platform.
  queue   View the job queue at the FedML® Launch platform (open.fedml.ai)
  status  Get status of job from the MLOps platform.
  stop    Stop a job from the MLOps platform.

```