### PR TITLE
Update storage logic; support download dest

### DIFF
--- a/python/fedml/api/__init__.py
+++ b/python/fedml/api/__init__.py
@@ -180,8 +180,8 @@ def upload(data_path, api_key=None, name=None, show_progress=False, out_progress
                           show_progress=show_progress, out_progress_to_err=out_progress_to_err)
 
 
-def download(data_name, api_key=None):
-    return storage.download(data_name, api_key)
+def download(data_name, api_key=None, dest_path=None):
+    return storage.download(data_name=data_name, api_key=api_key, dest_path=dest_path)
 
 
 def fedml_build(platform, type, source_folder, entry_point, config_folder, dest_folder, ignore):

--- a/python/fedml/api/modules/storage.py
+++ b/python/fedml/api/modules/storage.py
@@ -4,17 +4,17 @@ import shutil
 from fedml.api.modules.utils import authenticate
 from fedml.core.distributed.communication.s3.remote_storage import S3Storage
 from fedml.core.mlops.mlops_configs import Configs, MLOpsConfigs
+from fedml.computing.scheduler.master.server_constants import ServerConstants
 
 
-def upload(data_path, api_key, name, show_progress, out_progress_to_err, progress_desc) -> str:
-    authenticate(api_key)
+def upload(data_path, api_key, name, show_progress, out_progress_to_err, progress_desc) -> str | None:
+    api_key = authenticate(api_key)
+    user_id = _get_user_id_from_api_key(api_key)
+    if user_id is None:
+        print(f"Failed to get user id from api key: {api_key}")
+        return None
     configs = MLOpsConfigs.fetch_remote_storage_configs()
     r2_config = configs[Configs.R2_CONFIG]
-    # Todo: Delete following
-    # r2_config = {'BUCKET_NAME': 'dataset',
-    #              'CN_S3_ENDPOINT': 'https://03aa47c68e20656e11ca9e0765c6bc1f.r2.cloudflarestorage.com',
-    #              'CN_S3_AKI': '44b582b7fe45ec884ec011d34f1da78d',
-    #              'CN_S3_SAK': '41ea9ff0536ddf35daf5963da552a6c576c3a66e2359dffe148cf3162d8b2de6'}
     s3 = S3Storage(r2_config)
     src_local_path = os.path.abspath(data_path)
     root_dir = os.path.dirname(src_local_path)
@@ -30,7 +30,8 @@ def upload(data_path, api_key, name, show_progress, out_progress_to_err, progres
     except Exception as e:
         print(f"Error archiving data: {e}")
         return None
-    dest_path = os.path.join(api_key, os.path.basename(archive_path))
+
+    dest_path = os.path.join(user_id, os.path.basename(archive_path))
     file_uploaded_url = s3.upload_file_with_progress(src_local_path=archive_path, dest_s3_path=dest_path,
                                                      show_progress=show_progress,
                                                      out_progress_to_err=out_progress_to_err,
@@ -39,27 +40,50 @@ def upload(data_path, api_key, name, show_progress, out_progress_to_err, progres
     return file_uploaded_url
 
 
-def download(data_name, api_key) -> str:
-    authenticate(api_key)
+def download(data_name, api_key=None, dest_path=None) -> str | None:
+    api_key = authenticate(api_key)
+    user_id = _get_user_id_from_api_key(api_key)
+    if user_id is None:
+        print(f"Failed to get user id from api key: {api_key}")
+        return None
     configs = MLOpsConfigs.fetch_remote_storage_configs()
     r2_config = configs[Configs.R2_CONFIG]
-    # Todo: Delete following
-    # r2_config = {'BUCKET_NAME': 'dataset',
-    #              'CN_S3_ENDPOINT': 'https://03aa47c68e20656e11ca9e0765c6bc1f.r2.cloudflarestorage.com',
-    #              'CN_S3_AKI': '44b582b7fe45ec884ec011d34f1da78d',
-    #              'CN_S3_SAK': '41ea9ff0536ddf35daf5963da552a6c576c3a66e2359dffe148cf3162d8b2de6'}
     s3 = S3Storage(r2_config)
     zip_file_name = data_name + ".zip"
-    key = os.path.join(api_key, zip_file_name)
+    key = os.path.join(user_id, zip_file_name)
     path_local = os.path.abspath(zip_file_name)
+    dest_path = os.path.abspath(dest_path) if dest_path else data_name
     if s3.download_file_with_progress(path_s3=key, path_local=path_local):
         try:
-            shutil.unpack_archive(path_local, data_name)
+            shutil.unpack_archive(path_local, dest_path)
             os.remove(path_local)
-            return os.path.abspath(data_name)
+            return os.path.abspath(dest_path)
         except Exception as e:
             logging.error(f"Failed to unpack archive: {e}")
             return None
     else:
         logging.error(f"Failed to download data: {data_name}")
         return None
+
+
+def _get_user_id_from_api_key(api_key: str) -> str:
+    user_url = ServerConstants.get_user_url()
+    json_data = {
+        "apiKey": api_key
+    }
+    response = ServerConstants.request(user_url, json_data)
+    if response.status_code != 200:
+        print(f"Failed to get user info with response.status_code = {response.status_code}, "
+              f"response.content: {response.content}")
+        return None
+    else:
+        resp_data = response.json()
+        code = resp_data.get("code", None)
+        data = resp_data.get("data", None)
+        if code is None or data is None or code == "FAILURE":
+            message = resp_data.get("message", None)
+            print(f"Failed querying user info with following meesage: {message}"
+                  f"response.content: {response.content}")
+            return None
+    user_id = data.get("id", None)
+    return str(user_id) if user_id else None

--- a/python/fedml/api/modules/utils.py
+++ b/python/fedml/api/modules/utils.py
@@ -41,6 +41,8 @@ def authenticate(api_key):
         raise SystemExit(f"Failed to authenticate with apikey: '{api_key}'. Please make sure your login "
                          f"credentials are valid.")
 
+    return api_key
+
 
 def build_mlops_package(
         ignore,

--- a/python/fedml/cli/modules/storage.py
+++ b/python/fedml/cli/modules/storage.py
@@ -85,7 +85,9 @@ def list_data(version, api_key):
 @fedml_storage.command("download", help="Download data stored on FedML® Nexus AI Platform")
 @click.help_option("--help", "-h")
 @click.argument("data_name", nargs=1, callback=validate_argument)
-@click.option("--dest_path", "-d", default=None, type=str, help="Destination path to download data.")
+@click.option("--dest_path", "-d", default=None, type=str, help="Destination path to download data. By default, "
+                                                                "it would be downloaded to working directory from "
+                                                                "where the command is executed.")
 @click.option(
     "--api_key", "-k", type=str, help="user api key.",
 )

--- a/python/fedml/cli/modules/storage.py
+++ b/python/fedml/cli/modules/storage.py
@@ -85,6 +85,7 @@ def list_data(version, api_key):
 @fedml_storage.command("download", help="Download data stored on FedML® Nexus AI Platform")
 @click.help_option("--help", "-h")
 @click.argument("data_name", nargs=1, callback=validate_argument)
+@click.option("--dest_path", "-d", default=None, type=str, help="Destination path to download data.")
 @click.option(
     "--api_key", "-k", type=str, help="user api key.",
 )
@@ -95,9 +96,9 @@ def list_data(version, api_key):
     default="release",
     help=version_help,
 )
-def download(data_name, version, api_key):
+def download(data_name, dest_path, version, api_key):
     fedml.set_env_version(version)
-    data_download_path = fedml.api.download(data_name, api_key)
+    data_download_path = fedml.api.download(data_name=data_name, dest_path=dest_path, api_key=api_key)
     if data_download_path:
         click.echo(f"Data downloaded successfully at: {data_download_path}")
     else:


### PR DESCRIPTION
1. Updated logic to store in `userId/file` format instead of `apikey/file` format in R2 buckets. This is important because apiKey can be rotated but userId wouldn't rotate ever.
2. Support downloading and unzipping file at specified destination directory. Defaults to working directory if not provided.