### PR TITLE
MPI Graceful Shutdown and Import Stmt Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,3 +274,4 @@ python/tests/test_model_cli/llm_deploy/src/constants/__init__.py
 python/tests/test_model_cli/llm_deploy/src/constants/prompt_template.py
 python/examples/launch/hello_world/bootstrap.bat
 python/examples/launch/hello_world/fedml_job_entry_pack.bat
+**mpi_host_file

--- a/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/README.md
+++ b/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/README.md
@@ -1,0 +1,4 @@
+# Install FedML and Prepare the Distributed Environment
+```
+pip install fedml
+```

--- a/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/config/fedml_config.yaml
+++ b/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/config/fedml_config.yaml
@@ -1,0 +1,43 @@
+common_args:
+  training_type: "simulation"
+  using_mlops: false
+  random_seed: 0
+
+data_args:
+  dataset: "mnist"
+  data_cache_dir: ~/.cache/fedml_data
+  partition_method: "hetero"
+  partition_alpha: 0.5
+
+model_args:
+  model: "lr"
+
+train_args:
+  federated_optimizer: "FedAvg" # others "FedAsync", "FedBuff"
+  # is_async: false
+  # buffer_size: 0 # 
+  # max_acceptable_staleness: 0
+  client_num_in_total: 3
+  client_num_per_round: 3
+  comm_round: 3
+  epochs: 1
+  batch_size: 10
+  client_optimizer: sgd
+  learning_rate: 0.03
+  sleep_time_max: 3  # maximum number of seconds a client can sleep betwene training cycles.
+
+validation_args:
+  frequency_of_the_test: 5
+
+device_args:
+  worker_num: 3
+  using_gpu: false
+  gpu_mapping_file:
+  gpu_mapping_key:
+
+comm_args:
+  backend: "MPI"
+
+tracking_args:
+   # When running on MLOps platform(open.fedml.ai), the default log path is at ~/.fedml/fedml-client/fedml/logs/ and ~/.fedml/fedml-server/fedml/logs/
+  enable_wandb: false

--- a/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/run_example.sh
+++ b/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/run_example.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+WORKER_NUM=$1
+
+PROCESS_NUM=`expr $WORKER_NUM + 1`
+echo $PROCESS_NUM
+
+hostname > mpi_host_file
+
+mpirun \
+-np $PROCESS_NUM \
+-hostfile mpi_host_file --oversubscribe \
+python -m mpi4py torch_main.py --cf config/fedml_config.yaml

--- a/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/torch_main.py
+++ b/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/torch_main.py
@@ -1,0 +1,77 @@
+import fedml
+import torch
+
+from fedml import FedMLRunner
+from fedml.data.MNIST.data_loader import download_mnist, load_partition_data_mnist
+from trainer.custom_aggregator import CustomAggregator
+from trainer.custom_trainer_async import CustomTrainerAsync
+
+def load_data(args):
+    download_mnist(args.data_cache_dir)
+    fedml.logging.info("load_data. dataset_name = %s" % args.dataset)
+
+    """
+    Please read through the data loader at to see how to customize the dataset for FedML framework.
+    """
+    (
+        client_num,
+        train_data_num,
+        test_data_num,
+        train_data_global,
+        test_data_global,
+        train_data_local_num_dict,
+        train_data_local_dict,
+        test_data_local_dict,
+        class_num,
+    ) = load_partition_data_mnist(
+        args,
+        args.batch_size,
+        train_path=args.data_cache_dir + "/MNIST/train",
+        test_path=args.data_cache_dir + "/MNIST/test",
+    )
+    """
+    For shallow NN or linear models, 
+    we uniformly sample a fraction of clients each round (as the original FedAvg paper)
+    """
+    args.client_num_in_total = client_num
+    dataset = [
+        train_data_num,
+        test_data_num,
+        train_data_global,
+        test_data_global,
+        train_data_local_num_dict,
+        train_data_local_dict,
+        test_data_local_dict,
+        class_num,
+    ]
+    return dataset, class_num
+
+
+class LogisticRegression(torch.nn.Module):
+    def __init__(self, input_dim, output_dim):
+        super(LogisticRegression, self).__init__()
+        self.linear = torch.nn.Linear(input_dim, output_dim)
+
+    def forward(self, x):
+        outputs = torch.sigmoid(self.linear(x))
+        return outputs
+
+
+if __name__ == "__main__":
+    # init FedML framework
+    args = fedml.init()
+
+    # init device
+    device = fedml.device.get_device(args)
+
+    # load data
+    dataset, output_dim = load_data(args)
+
+    # load model (the size of MNIST image is 28 x 28)
+    model = LogisticRegression(28 * 28, output_dim)
+    trainer = CustomTrainerAsync(model=model, args=args)
+    aggregator = CustomAggregator(model=model, args=args)
+
+    # start training
+    fedml_runner = FedMLRunner(args, device, dataset, model, trainer, aggregator)
+    fedml_runner.run()

--- a/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/trainer/custom_aggregator.py
+++ b/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/trainer/custom_aggregator.py
@@ -1,0 +1,48 @@
+import logging
+
+import torch
+import torch.nn as nn
+
+from fedml.core import ServerAggregator
+
+
+class CustomAggregator(ServerAggregator):
+
+    def __init__(self, model, args=None):
+        super().__init__(model, args)
+
+    def get_model_params(self):
+        return self.model.state_dict()
+
+    def set_model_params(self, model_parameters):
+        logging.info("set_model_params")
+        self.model.load_state_dict(model_parameters)
+
+    def test(self, test_data, device, args):
+        self.model.to(device)
+        self.model.eval()
+
+        metrics = {
+            "test_correct": 0,
+            "test_loss": 0,
+            "test_precision": 0,
+            "test_recall": 0,
+            "test_total": 0,
+        }
+
+        criterion = nn.CrossEntropyLoss().to(device)
+        with torch.no_grad():
+            for batch_idx, (x, target) in enumerate(test_data):
+                x = x.to(device)
+                target = target.to(device)
+                pred = self.model(x)
+                loss = criterion(pred, target)  # pylint: disable=E1102
+                # _, predicted = torch.max(pred, 1)
+                # correct = predicted.eq(target).sum()
+
+                # metrics["test_correct"] += correct.item()
+
+        return metrics
+
+    def test_all(self, train_data_local_dict, test_data_local_dict, device, args=None) -> bool:
+        return True

--- a/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/trainer/custom_trainer_async.py
+++ b/python/examples/federate/simulation/mpi_torch_custom_async_mnist_lr_example/trainer/custom_trainer_async.py
@@ -1,0 +1,99 @@
+import logging
+import time
+import torch
+
+import numpy as np
+
+from scipy.stats import expon
+from torch import nn
+
+from fedml.core.alg_frame.client_trainer import ClientTrainer
+
+class CustomTrainerAsync(ClientTrainer):
+
+    def __init__(self, model, args=None):
+        super().__init__(model, args)
+
+        # In classical FL, the time a client requires to perform local 
+        # training is proportional to the client's number of examples.
+        # For our simulation here, since clients have an equal number 
+        # of samples, we assume the time delay is proportional to the 
+        # client's rank in the FL environment.
+
+        # Formally, let (ni)/(ri) be the (number of examples)/(rank) 
+        # of client i, and let Ti be the amount of time required by 
+        # client i to perform local training, with λ > 0 being a
+        # constant number controlling stragglers' behavior:
+        #   T(n) ~ exp(1/λn) OR 
+        #   T(r) ~ exp(1/λr)
+
+        # Smulation References:
+        # - Speeding Up Distributed Machine Learning Using Codes 
+        #   https://arxiv.org/pdf/1512.02673.pdf
+        # - Federated Learning with Buffered Asynchronous Aggregation
+        #   https://proceedings.mlr.press/v151/nguyen22b/nguyen22b.pdf 
+        self.expon_lambda = 0.5
+        self.expon_scale = np.divide(1, self.expon_lambda)
+        self.sleep_time_max = args.sleep_time_max
+
+    def get_model_params(self):
+        return self.model.state_dict()
+
+    def set_model_params(self, model_parameters):
+        self.model.load_state_dict(model_parameters)
+
+    def train(self, train_data, device, args):
+        # Adding following line to emulate random sleeping patterns 
+        # across clients for testing asynchronous FL strategies.
+        # x is client's rank
+        sleep_time = expon.pdf(args.rank + 1, self.expon_scale) 
+        sleep_time *= self.sleep_time_max
+        sleep_time = np.round(sleep_time, 2)
+        logging.info("Client: {}, Sleep time: {} secs".format(args.rank, sleep_time))
+        time.sleep(sleep_time)
+        model = self.model
+
+        model.to(device)
+        model.train()
+
+        criterion = nn.CrossEntropyLoss().to(device)
+        if args.client_optimizer == "sgd":
+            optimizer = torch.optim.SGD(model.parameters(), lr=args.learning_rate)
+        else:
+            optimizer = torch.optim.Adam(
+                filter(lambda p: p.requires_grad, model.parameters()),
+                lr=args.learning_rate,
+                weight_decay=args.weight_decay,
+                amsgrad=True,
+            )
+
+        epoch_loss = []
+        for epoch in range(args.epochs):
+            batch_loss = []
+            for batch_idx, (x, labels) in enumerate(train_data):
+                # logging.info(images.shape)
+                x, labels = x.to(device), labels.to(device)
+                optimizer.zero_grad()
+                log_probs = model(x)
+                loss = criterion(log_probs, labels)  # pylint: disable=E1102
+                loss.backward()
+                optimizer.step()
+                batch_loss.append(loss.item())
+                if batch_idx % 100 == 0:
+                    logging.info(
+                        "Epoch: {}/{} | Batch: {}/{} | Loss: {}".format(
+                            epoch + 1,
+                            args.epochs,
+                            batch_idx,
+                            len(train_data),
+                            loss.item(),
+                        )
+                    )
+
+            if len(batch_loss) > 0:
+                epoch_loss.append(sum(batch_loss) / len(batch_loss))
+                logging.info(
+                    "(Trainer_ID {}. Local Training Epoch: {} \tLoss: {:.6f}".format(
+                        self.id, epoch, sum(epoch_loss) / len(epoch_loss)
+                    )
+                )

--- a/python/fedml/__init__.py
+++ b/python/fedml/__init__.py
@@ -212,9 +212,9 @@ def _update_client_specific_args(args):
 
 
 def _init_simulation_mpi(args):
-    import mpi4py
+    from mpi4py import MPI
 
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     world_size = comm.Get_size()
     args.comm = comm
@@ -310,9 +310,9 @@ def _manage_cuda_rpc_args(args):
 
 def _manage_mpi_args(args):
     if hasattr(args, "backend") and args.backend == "MPI":
-        import mpi4py
+        from mpi4py import MPI
 
-        comm = mpi4py.MPI.COMM_WORLD
+        comm = MPI.COMM_WORLD
         process_id = comm.Get_rank()
         world_size = comm.Get_size()
         args.comm = comm

--- a/python/fedml/computing/scheduler/comm_utils/sys_utils.py
+++ b/python/fedml/computing/scheduler/comm_utils/sys_utils.py
@@ -73,7 +73,7 @@ def get_sys_runner_info():
         pass
 
     try:
-        import mpi4py
+        from mpi4py import MPI
         mpi_obj = mpi4py.MPI
         mpi_installed = True
     except:

--- a/python/fedml/computing/scheduler/env/collect_env.py
+++ b/python/fedml/computing/scheduler/env/collect_env.py
@@ -32,7 +32,7 @@ def collect_env():
         print("PyTorch is not installed properly")
 
     try:
-        import mpi4py
+        from mpi4py import MPI
         mpi_obj = mpi4py.MPI
         print("MPI4py is installed")
     except:

--- a/python/fedml/core/distributed/fedml_comm_manager.py
+++ b/python/fedml/core/distributed/fedml_comm_manager.py
@@ -66,9 +66,9 @@ class FedMLCommManager(Observer):
     def finish(self):
         logging.info("__finish")
         if self.backend == "MPI":
-            import mpi4py
-
-            mpi4py.MPI.COMM_WORLD.Abort()
+            from mpi4py import MPI
+            self.com_manager.stop_receive_message()
+            MPI.Finalize()
         elif self.backend == "MQTT":
             self.com_manager.stop_receive_message()
         elif self.backend == "MQTT_S3":

--- a/python/fedml/fa/__init__.py
+++ b/python/fedml/fa/__init__.py
@@ -32,9 +32,9 @@ def init(args=None):
 
 def manage_mpi_args(args):
     if hasattr(args, "backend") and args.backend == "MPI":
-        import mpi4py
+        from mpi4py import MPI
 
-        comm = mpi4py.MPI.COMM_WORLD
+        comm = MPI.COMM_WORLD
         process_id = comm.Get_rank()
         world_size = comm.Get_size()
         args.comm = comm

--- a/python/fedml/simulation/mpi/base_framework/algorithm_api.py
+++ b/python/fedml/simulation/mpi/base_framework/algorithm_api.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 
 from .central_manager import BaseCentralManager
 from .central_worker import BaseCentralWorker
@@ -7,7 +7,7 @@ from .client_worker import BaseClientWorker
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
     return comm, process_id, worker_number

--- a/python/fedml/simulation/mpi/classical_vertical_fl/vfl_api.py
+++ b/python/fedml/simulation/mpi/classical_vertical_fl/vfl_api.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 
 from .guest_manager import GuestManager
 from .guest_trainer import GuestTrainer
@@ -7,7 +7,7 @@ from .host_trainer import HostTrainer
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
     return comm, process_id, worker_number

--- a/python/fedml/simulation/mpi/fedgan/FedGanAPI.py
+++ b/python/fedml/simulation/mpi/fedgan/FedGanAPI.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 
 from .FedGANAggregator import FedGANAggregator
 from .FedGANTrainer import FedGANTrainer
@@ -8,7 +8,7 @@ from .gan_trainer import GANTrainer
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
 

--- a/python/fedml/simulation/mpi/fedgkt/FedGKTAPI.py
+++ b/python/fedml/simulation/mpi/fedgkt/FedGKTAPI.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 
 from .GKTClientManager import GKTClientMananger
 from .GKTClientTrainer import GKTClientTrainer
@@ -7,7 +7,7 @@ from .GKTServerTrainer import GKTServerTrainer
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
     return comm, process_id, worker_number

--- a/python/fedml/simulation/mpi/fednas/FedNASAPI.py
+++ b/python/fedml/simulation/mpi/fednas/FedNASAPI.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 
 from fedml.core import ClientTrainer, ServerAggregator
 from .FedNASAggregator import FedNASAggregator
@@ -8,7 +8,7 @@ from .FedNASTrainer import FedNASTrainer
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
     return comm, process_id, worker_number

--- a/python/fedml/simulation/mpi/fedopt/FedOptAPI.py
+++ b/python/fedml/simulation/mpi/fedopt/FedOptAPI.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 
 from .FedOptAggregator import FedOptAggregator
 from .FedOptClientManager import FedOptClientManager
@@ -10,7 +10,7 @@ from ....ml.trainer.trainer_creator import create_model_trainer
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
     return comm, process_id, worker_number

--- a/python/fedml/simulation/mpi/fedopt_seq/FedOptSeqAPI.py
+++ b/python/fedml/simulation/mpi/fedopt_seq/FedOptSeqAPI.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 
 from .FedOptAggregator import FedOptAggregator
 from .FedOptClientManager import FedOptClientManager
@@ -10,7 +10,7 @@ from ....ml.trainer.trainer_creator import create_model_trainer
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
     return comm, process_id, worker_number

--- a/python/fedml/simulation/mpi/fedprox/FedProxAPI.py
+++ b/python/fedml/simulation/mpi/fedprox/FedProxAPI.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 
 from ....core import ClientTrainer, ServerAggregator
 from ....ml.aggregator.aggregator_creator import create_server_aggregator
@@ -10,7 +10,7 @@ from .FedProxTrainer import FedProxTrainer
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
     return comm, process_id, worker_number

--- a/python/fedml/simulation/mpi/fedseg/FedSegAPI.py
+++ b/python/fedml/simulation/mpi/fedseg/FedSegAPI.py
@@ -1,6 +1,6 @@
 import logging
 
-import mpi4py
+from mpi4py import MPI
 
 from .FedSegAggregator import FedSegAggregator
 from .FedSegClientManager import FedSegClientManager
@@ -10,7 +10,7 @@ from .MyModelTrainer import MyModelTrainer
 
 
 def FedML_init():
-    comm = mpi4py.MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD
     process_id = comm.Get_rank()
     worker_number = comm.Get_size()
     return comm, process_id, worker_number

--- a/python/fedml/simulation/mpi/split_nn/SplitNNAPI.py
+++ b/python/fedml/simulation/mpi/split_nn/SplitNNAPI.py
@@ -1,4 +1,4 @@
-import mpi4py
+from mpi4py import MPI
 from torch import nn
 
 from .client import SplitNN_client

--- a/python/fedml/simulation/nccl/base_framework/common.py
+++ b/python/fedml/simulation/nccl/base_framework/common.py
@@ -147,7 +147,7 @@ def FedML_NCCL_Similulation_init(args):
 
 
 # def FedML_NCCL_init(args):
-#     # comm = mpi4py.MPI.COMM_WORLD
+#     # comm = MPI.COMM_WORLD
 #     # process_id = comm.Get_rank()
 #     # worker_number = comm.Get_size()
 #     comm, global_rank, world_size = FedML_NCCL_Similulation_init(args)

--- a/python/fedml/utils/context.py
+++ b/python/fedml/utils/context.py
@@ -2,7 +2,7 @@ import threading
 import traceback
 from contextlib import contextmanager
 
-import mpi4py
+from mpi4py import MPI
 
 
 @contextmanager
@@ -15,7 +15,7 @@ def raise_MPI_error():
     except Exception as e:
         logging.info(e)
         logging.info("traceback.format_exc():\n%s" % traceback.format_exc())
-        mpi4py.MPI.COMM_WORLD.Abort()
+        MPI.COMM_WORLD.Abort()
 
 
 @contextmanager


### PR DESCRIPTION
1. Changed mpi4py import statement throughout the library to avoid reference error
2. removed ABORT call from fedml_comm_mamager and use MPI.Finalize() for graceful shutdown of the environment
3. restructured mpi/com_mamanger to properly release resources
4. introduced asynchronous (non-blocking) reception of messages in the MPI communication channel of the MPIReceiveThread.