### PR TITLE
Fix order to have accurate error message

### DIFF
--- a/python/fedml/api/modules/launch.py
+++ b/python/fedml/api/modules/launch.py
@@ -230,10 +230,6 @@ def _parse_create_result(result: FedMLRunStartedModel, yaml_file) -> (int, str):
         return (ApiConstants.ERROR_CODE[ApiConstants.RESOURCE_MATCHED_STATUS_JOB_URL_ERROR],
                 ApiConstants.RESOURCE_MATCHED_STATUS_JOB_URL_ERROR)
 
-    if result.gpu_matched is None or len(result.gpu_matched) == 0:
-        return (ApiConstants.ERROR_CODE[ApiConstants.RESOURCE_MATCHED_STATUS_NO_RESOURCES],
-                f"\nNo resource available now, please modify the resource type or try it again later.")
-
     if result.status == Constants.JOB_START_STATUS_LAUNCHED:
         return (ApiConstants.ERROR_CODE[ApiConstants.RESOURCE_MATCHED_STATUS_MATCHED],
                 ApiConstants.RESOURCE_MATCHED_STATUS_MATCHED)
@@ -292,6 +288,10 @@ def _parse_create_result(result: FedMLRunStartedModel, yaml_file) -> (int, str):
     elif result.status != Constants.JOB_START_STATUS_SUCCESS:
         return (ApiConstants.ERROR_CODE[ApiConstants.LAUNCH_JOB_STATUS_NO_SPECIFIC_ERROR],
                 result.message)
+
+    if result.gpu_matched is None or len(result.gpu_matched) == 0:
+        return (ApiConstants.ERROR_CODE[ApiConstants.RESOURCE_MATCHED_STATUS_NO_RESOURCES],
+                f"\nNo resource available now, please modify the resource type or try it again later.")
 
     return (ApiConstants.ERROR_CODE[ApiConstants.RESOURCE_MATCHED_STATUS_MATCHED],
             ApiConstants.RESOURCE_MATCHED_STATUS_MATCHED)


### PR DESCRIPTION
### Before
```
fedml launch test/job.yaml -v test -k dc7a556a08cc4f219dad3fc53a0a8611 
Submitting your job to FedML® Nexus AI Platform: 100%|██████████| 2.71k/2.71k [00:00<00:00, 13.5kB/s]

No resource available now, please modify the resource type or try it again later.

Process finished with exit code 0
```

### After:
```
fedml launch test/job.yaml -v test -k dc7a556a08cc4f219dad3fc53a0a8611 
Submitting your job to FedML® Nexus AI Platform: 100%|██████████| 2.71k/2.71k [00:00<00:00, 17.9kB/s]

        Before we can start a job, please add a credit card to your FEDML account at https://nexus.fedml.ai/billing/home.
        Once it's added, please try to run the launch command again
        

Process finished with exit code 0
```