### PR TITLE
Fix Docker Mapping Issue

### DIFF
--- a/python/fedml/computing/scheduler/comm_utils/job_utils.py
+++ b/python/fedml/computing/scheduler/comm_utils/job_utils.py
@@ -405,10 +405,12 @@ class JobRunnerUtils(Singleton):
 
         docker_command = ["docker", "run", "-t", "--rm", "--name", f"{container_name}"]
 
-        # Remove "export CUDA_VISIBLE_DEVICES=" from entry file and add as dockeer command instead:
+        # Remove "export CUDA_VISIBLE_DEVICES=" from entry file and add as docker command instead:
         if cuda_visible_gpu_ids_str is not None:
             JobRunnerUtils.remove_cuda_visible_devices_lines(entry_file_full_path)
-            docker_command.extend(["--gpus", f'"{cuda_visible_gpu_ids_str}"'])
+            # docker command expects device ids in such format: '"device=0,2,3"'
+            device_str = f'"device={cuda_visible_gpu_ids_str}"'
+            docker_command.extend(["--gpus", f"'{device_str}'"])
 
         # Add Port Mapping
         for port in docker_args.ports:


### PR DESCRIPTION
# Before
```
DEBUG ENDED: generate_launch_docker_command returned ['docker run -t --rm --name fedml_default_launch_container__1750672502998306816 --gpus 4,5 ...]
```

# With this fix

```
DEBUG ENDED: generate_launch_docker_command returned ['docker run -t --rm --name fedml_default_launch_container__1750672502998306816 --gpus \'"device=4,5"\' -p 0:2345 -v /home/user/
.fedml/fedml-client/fedml/logs/fedml-run-1750672502998306816-edge-1499.log:/home/user/.fedml/fedml-client/fedml/logs/fedml-run-1750672502998306816-edge-1499.log:rw -v /home/user/.fe
dml/fedml-client/fedml_packages/unzip_fedml_run_1750672502998306816_hello_world_FedMLLaunchApp@ff736e8e-5270-4372-9114-bd9de7962fb1/client-package/:/home/user/.fedml/fedml-client/fe
dml_packages/unzip_fedml_run_1750672502998306816_hello_world_FedMLLaunchApp@ff736e8e-5270-4372-9114-bd9de7962fb1/client-package/:rw -w /home/user/.fedml/fedml-client/fedml_packages/
unzip_fedml_run_1750672502998306816_hello_world_FedMLLaunchApp@ff736e8e-5270-4372-9114-bd9de7962fb1/client-package/fedml fedml/fedml-default-launch:cu12.1-u22.04 bash -c "cd /home/u
ser/.fedml/fedml-client/fedml_packages/unzip_fedml_run_1750672502998306816_hello_world_FedMLLaunchApp@ff736e8e-5270-4372-9114-bd9de7962fb1/client-package/fedml/ && ./bootstrap.sh &&
 chmod +x /home/user/.fedml/fedml-client/fedml_packages/unzip_fedml_run_1750672502998306816_hello_world_FedMLLaunchApp@ff736e8e-5270-4372-9114-bd9de7962fb1/client-package/fedml/fedm
l_job_entry_pack.sh && /home/user/.fedml/fedml-client/fedml_packages/unzip_fedml_run_1750672502998306816_hello_world_FedMLLaunchApp@ff736e8e-5270-4372-9114-bd9de7962fb1/client-packa
ge/fedml/fedml_job_entry_pack.sh"']
```