### PR TITLE
Fix Login

### DIFF
--- a/python/fedml/computing/scheduler/master/server_daemon.py
+++ b/python/fedml/computing/scheduler/master/server_daemon.py
@@ -113,17 +113,18 @@ if __name__ == "__main__":
                 retry_flag = False
 
                 if os.path.exists(login_exit_file):
-                    message = f"[Server] Login process is exited, check the exit file {login_exit_file}"
-                    print(message)
+                    print(f"[Server] Login process is exited, check the exit file {login_exit_file}")
                     if retry_count > 3:
-                        raise Exception(message)
+                        print("Retry count is over 3 times, exit the process.")
+                        exit(1)
                     retry_flag = True
 
                 if len(login_pids) == 0:
                     message = f"[Server] Login process is exited, check the log file {login_logs}"
                     print(message)
                     if retry_count >= 3:
-                        raise Exception(message)
+                        print("Retry count is over 3 times, exit the process.")
+                        exit(1)
                     retry_flag = True
 
                 if retry_flag:

--- a/python/fedml/computing/scheduler/master/server_daemon.py
+++ b/python/fedml/computing/scheduler/master/server_daemon.py
@@ -123,7 +123,8 @@ if __name__ == "__main__":
                     message = f"[Server] Login process is exited, check the log file {login_logs}"
                     print(message)
                     if retry_count >= 3:
-                        print("Retry count is over 3 times, exit the process.")
+                        print(f"Retry count is over 3 times, exit the process. Check the log file for more details. "
+                              f"Login logs: {login_logs}, Exit file: {login_exit_file}")
                         exit(1)
                     retry_flag = True
 

--- a/python/fedml/computing/scheduler/master/server_daemon.py
+++ b/python/fedml/computing/scheduler/master/server_daemon.py
@@ -115,7 +115,8 @@ if __name__ == "__main__":
                 if os.path.exists(login_exit_file):
                     print(f"[Server] Login process is exited, check the exit file {login_exit_file}")
                     if retry_count > 3:
-                        print("Retry count is over 3 times, exit the process.")
+                        print(f"Retry count is over 3 times, exit the process. Check the log file for more details. "
+                              f"Login logs: {login_logs}, Exit file: {login_exit_file}")
                         exit(1)
                     retry_flag = True
 

--- a/python/fedml/computing/scheduler/master/server_daemon.py
+++ b/python/fedml/computing/scheduler/master/server_daemon.py
@@ -38,7 +38,15 @@ if __name__ == "__main__":
     login_cmd = os.path.join(pip_source_dir, "server_login.py")
     login_exit_file = os.path.join(ServerConstants.get_log_file_dir(), "exited.log")
 
+    try:
+        if os.path.exists(login_exit_file):
+            os.remove(login_exit_file)
+    except Exception as e:
+        logging.error(f"Remove failed | Exception: {e}")
+        pass
+
     log_line_count = 0
+    retry_count = 0
 
     while True:
         try:
@@ -48,13 +56,6 @@ if __name__ == "__main__":
             cleanup_all_fedml_server_login_processes("server_login.py", clean_process_group=False)
         except Exception as e:
             logging.error(f"Cleanup failed | Exception: {e}")
-            pass
-
-        try:
-            if os.path.exists(login_exit_file):
-                os.remove(login_exit_file)
-        except Exception as e:
-            logging.error(f"Remove failed | Exception: {e}")
             pass
 
         daemon_ota_upgrade(args)
@@ -108,15 +109,27 @@ if __name__ == "__main__":
                         log_line_count = len(log_list)
                 time.sleep(3)
                 login_pids = RunProcessUtils.get_pid_from_cmd_line(login_cmd)
+                login_exit_file = os.path.join(ServerConstants.get_log_file_dir(), "exited.log")
+                retry_flag = False
 
                 if os.path.exists(login_exit_file):
-                    print(f"[Server] Login process is exited, check the exit file {login_exit_file}")
-                    break
-                if len(login_pids) == 0:
-                    print(f"[Server] Login process is exited, check the log file {login_logs}")
-                    break
-            time.sleep(3)
+                    message = f"[Server] Login process is exited, check the exit file {login_exit_file}"
+                    print(message)
+                    if retry_count > 3:
+                        raise Exception(message)
+                    retry_flag = True
 
-            print("[Server] Retry to start the login process.")
+                if len(login_pids) == 0:
+                    message = f"[Server] Login process is exited, check the log file {login_logs}"
+                    print(message)
+                    if retry_count >= 3:
+                        raise Exception(message)
+                    retry_flag = True
+
+                if retry_flag:
+                    retry_count += 1
+
+            time.sleep(3)
+            print(f"[Server] Retry to start the login process. Retry count: {retry_count}")
 
 

--- a/python/fedml/computing/scheduler/slave/client_daemon.py
+++ b/python/fedml/computing/scheduler/slave/client_daemon.py
@@ -114,7 +114,8 @@ if __name__ == "__main__":
                     message = f"[Client] Login process is exited, check the exit file {login_exit_file}"
                     print(message)
                     if retry_count > 3:
-                        print("Retry count is over 3 times, exit the process.")
+                        print(f"Retry count is over 3 times, exit the process. Check the log file for more details. "
+                              f"Login logs: {login_logs}, Exit file: {login_exit_file}")
                         exit(1)
                     retry_flag = True
 

--- a/python/fedml/computing/scheduler/slave/client_daemon.py
+++ b/python/fedml/computing/scheduler/slave/client_daemon.py
@@ -122,7 +122,8 @@ if __name__ == "__main__":
                     message = f"[Client] Cannot find login pid {login_pids}, check the log file {login_logs}"
                     print(message)
                     if retry_count >= 3:
-                        print("Retry count is over 3 times, exit the process.")
+                        print(f"Retry count is over 3 times, exit the process. Check the log file for more details. "
+                              f"Login logs: {login_logs}, Exit file: {login_exit_file}")
                         exit(1)
                     retry_flag = True
 

--- a/python/fedml/computing/scheduler/slave/client_daemon.py
+++ b/python/fedml/computing/scheduler/slave/client_daemon.py
@@ -3,6 +3,7 @@ import argparse
 import os
 import time
 import platform
+import logging
 
 import fedml
 from fedml.computing.scheduler.comm_utils.sys_utils import cleanup_all_fedml_client_api_processes, \
@@ -37,7 +38,16 @@ if __name__ == "__main__":
     pip_source_dir = os.path.dirname(__file__)
     login_cmd = os.path.join(pip_source_dir, "client_login.py")
     login_exit_file = os.path.join(ClientConstants.get_log_file_dir(), "exited.log")
+
+    try:
+        if os.path.exists(login_exit_file):
+            os.remove(login_exit_file)
+    except Exception as e:
+        logging.error(f"Remove failed | Exception: {e}")
+        pass
+
     log_line_count = 0
+    retry_count = 0
 
     while True:
         try:
@@ -46,13 +56,9 @@ if __name__ == "__main__":
             cleanup_all_fedml_client_learning_processes()
             cleanup_all_fedml_client_login_processes("client_login.py", clean_process_group=False)
         except Exception as e:
+            logging.error(f"Cleanup failed | Exception: {e}")
             pass
 
-        try:
-            if os.path.exists(login_exit_file):
-                os.remove(login_exit_file)
-        except Exception as e:
-            pass
 
         daemon_ota_upgrade(args)
 
@@ -101,12 +107,25 @@ if __name__ == "__main__":
                         log_line_count = len(log_list)
                 time.sleep(3)
                 login_pids = RunProcessUtils.get_pid_from_cmd_line(login_cmd)
+                login_exit_file = os.path.join(ClientConstants.get_log_file_dir(), "exited.log")
+                retry_flag = False
 
                 if os.path.exists(login_exit_file):
-                    print(f"[Client] Login process is exited, check the exit file {login_exit_file}")
-                    break
+                    message = f"[Client] Login process is exited, check the exit file {login_exit_file}"
+                    print(message)
+                    if retry_count > 3:
+                        raise Exception(message)
+                    retry_flag = True
+
                 if len(login_pids) == 0:
-                    print(f"[Client] Cannot find login pid {login_pids}, check the log file {login_logs}")
-                    break
+                    message = f"[Client] Cannot find login pid {login_pids}, check the log file {login_logs}"
+                    print(message)
+                    if retry_count >= 3:
+                        raise Exception(message)
+                    retry_flag = True
+
+                if retry_flag:
+                    retry_count += 1
+
             time.sleep(3)
-            print("[Client] Retry to start the login process.")
+            print("[Client] Retry to start the login process. Retry count: {retry_count}")

--- a/python/fedml/computing/scheduler/slave/client_daemon.py
+++ b/python/fedml/computing/scheduler/slave/client_daemon.py
@@ -114,18 +114,20 @@ if __name__ == "__main__":
                     message = f"[Client] Login process is exited, check the exit file {login_exit_file}"
                     print(message)
                     if retry_count > 3:
-                        raise Exception(message)
+                        print("Retry count is over 3 times, exit the process.")
+                        exit(1)
                     retry_flag = True
 
                 if len(login_pids) == 0:
                     message = f"[Client] Cannot find login pid {login_pids}, check the log file {login_logs}"
                     print(message)
                     if retry_count >= 3:
-                        raise Exception(message)
+                        print("Retry count is over 3 times, exit the process.")
+                        exit(1)
                     retry_flag = True
 
                 if retry_flag:
                     retry_count += 1
 
             time.sleep(3)
-            print("[Client] Retry to start the login process. Retry count: {retry_count}")
+            print(f"[Client] Retry to start the login process. Retry count: {retry_count}")


### PR DESCRIPTION
FIx:
- If login errors, then the agent would stuck in a loop continuing to re-try forever and would also self remove logs due to a bug in logic hence user couldn't find the logs on why it errored. Fixed that, and now agent would try 3 times max and then exit.