### PR TITLE
Update trim unavailable gpu id logic

### DIFF
--- a/python/fedml/computing/scheduler/comm_utils/job_utils.py
+++ b/python/fedml/computing/scheduler/comm_utils/job_utils.py
@@ -136,16 +136,17 @@ class JobRunnerUtils(Singleton):
         return cuda_visible_gpu_ids_str, matched_gpu_num, matched_gpu_ids
 
     @staticmethod
-    def trim_unavailable_gpu_ids(gpu_ids):
+    def trim_unavailable_gpu_ids(gpu_ids) -> List[int]:
         # Trim the gpu ids based on the realtime available gpu id list.
+        available_gpu_ids = [int(gpu_id) for gpu_id in gpu_ids]
         gpu_list, realtime_available_gpu_ids = JobRunnerUtils.get_gpu_list_and_realtime_gpu_available_ids()
         unavailable_gpu_ids = list()
-        for index, gpu_id in enumerate(gpu_ids):
-            if int(gpu_id) not in realtime_available_gpu_ids:
-                unavailable_gpu_ids.append(index)
 
-        trimmed_gpu_ids = [gpu_id for index, gpu_id in enumerate(gpu_ids) if index not in unavailable_gpu_ids]
+        for gpu_id in available_gpu_ids:
+            if gpu_id not in realtime_available_gpu_ids:
+                unavailable_gpu_ids.append(gpu_id)
 
+        trimmed_gpu_ids = list(set(available_gpu_ids) - set(unavailable_gpu_ids))
         return trimmed_gpu_ids.copy()
 
     def release_gpu_ids(self, run_id, device_id):
@@ -258,7 +259,7 @@ class JobRunnerUtils(Singleton):
         return realtime_available_gpu_ids
 
     @staticmethod
-    def get_gpu_list_and_realtime_gpu_available_ids():
+    def get_gpu_list_and_realtime_gpu_available_ids() -> (List[dict], List[int]):
         gpu_list = sys_utils.get_gpu_list()
         gpu_count = len(gpu_list)
         realtime_available_gpu_ids = sys_utils.get_available_gpu_id_list(limit=gpu_count)

--- a/python/fedml/computing/scheduler/comm_utils/sys_utils.py
+++ b/python/fedml/computing/scheduler/comm_utils/sys_utils.py
@@ -4,6 +4,7 @@ import platform
 import signal
 import uuid
 from os.path import expanduser
+from typing import List
 
 import chardet
 import psutil
@@ -171,7 +172,7 @@ def get_gpu_list():
     return ret_gpu_list
 
 
-def get_available_gpu_id_list(limit=1):
+def get_available_gpu_id_list(limit=1) -> List[int]:
     if enable_simulation_gpu:
         available_gpu_ids = [0, 1, 2, 3, 4, 5, 6, 7]
         return available_gpu_ids


### PR DESCRIPTION
While reporting available gpu ids, we do following:

1. First get available gpu ids through real time availablility
2. Trim gpu ids that are already assigned to job which we store in redis cache

The current logic is bit complicated and hard to read and might break on edge cases. I modified it so it is easy to understand and reason about as we just create two sets and take a difference