### PR TITLE
[CoreEngine] 1. fix the issue which the gpu id is not released into t…

### DIFF
--- a/python/fedml/__init__.py
+++ b/python/fedml/__init__.py
@@ -34,7 +34,7 @@ from .core.common.ml_engine_backend import MLEngineBackend
 _global_training_type = None
 _global_comm_backend = None
 
-__version__ = "0.8.27.dev2"
+__version__ = "0.8.27.dev5"
 
 
 # This is the deployment environment used for different roles (RD/PM/BD/Public Developers). Potential VALUE: local, dev, test, release

--- a/python/fedml/computing/scheduler/comm_utils/job_utils.py
+++ b/python/fedml/computing/scheduler/comm_utils/job_utils.py
@@ -147,7 +147,7 @@ class JobRunnerUtils(Singleton):
         request_gpu_num = 0 if request_gpu_num is None else request_gpu_num
         matched_gpu_num = min(available_gpu_count, request_gpu_num)
         if matched_gpu_num <= 0 or matched_gpu_num != request_gpu_num:
-            return None, None, None
+            return None, None
 
         matched_gpu_ids = map(lambda x: str(x), available_gpu_ids[0:matched_gpu_num])
         cuda_visible_gpu_ids_str = ",".join(matched_gpu_ids)
@@ -195,7 +195,7 @@ class JobRunnerUtils(Singleton):
                         ComputeCacheManager.get_instance().get_gpu_cache().get_device_lock_key(edge_device_id)
                 ):
                     available_gpu_ids = ComputeCacheManager.get_instance().get_gpu_cache().get_device_available_gpu_ids(
-                        device_id)
+                        edge_device_id)
                     available_gpu_ids.extend(run_gpu_ids.copy())
                     available_gpu_ids = list(dict.fromkeys(available_gpu_ids))
                     ComputeCacheManager.get_instance().get_gpu_cache().set_device_available_gpu_ids(

--- a/python/fedml/computing/scheduler/scheduler_core/compute_gpu_cache.py
+++ b/python/fedml/computing/scheduler/scheduler_core/compute_gpu_cache.py
@@ -87,6 +87,8 @@ class ComputeGpuCache(object):
         if device_available_gpu_ids is not None and str(device_available_gpu_ids).strip() != "":
             device_available_gpu_ids = device_available_gpu_ids.split(',')
             device_available_gpu_ids = self.map_str_list_to_int_list(device_available_gpu_ids)
+        else:
+            return []
 
         return device_available_gpu_ids
 

--- a/python/fedml/core/mlops/mlops_device_perfs.py
+++ b/python/fedml/core/mlops/mlops_device_perfs.py
@@ -167,8 +167,11 @@ class MLOpsDevicePerfStats(object):
 
         topic_name = "ml_client/mlops/gpu_device_info"
 
-        gpu_available_ids = JobRunnerUtils.get_available_gpu_id_list(edge_id)
-        gpu_available_ids = JobRunnerUtils.trim_unavailable_gpu_ids(gpu_available_ids)
+        # We should report realtime available gpu count to MLOps, not from local redis cache.
+        # Use gpu_available_ids from sys_utils.get_sys_realtime_stats()
+        # Do not use the following two lines as the realtime available gpu ids.
+        # gpu_available_ids = JobRunnerUtils.get_available_gpu_id_list(edge_id)
+        # gpu_available_ids = JobRunnerUtils.trim_unavailable_gpu_ids(gpu_available_ids)
         gpu_cores_available = len(gpu_available_ids)
         deploy_worker_id_list = list()
         try:

--- a/python/setup.py
+++ b/python/setup.py
@@ -116,7 +116,7 @@ requirements_extra_deepspeed = [
 
 setup(
     name="fedml",
-    version="0.8.27.dev2",
+    version="0.8.27.dev5",
     author="FedML Team",
     author_email="ch@fedml.ai",
     description="A research and production integrated edge-cloud library for "


### PR DESCRIPTION
…he local redis when deleting the endpoint. 2. report the realtime gpu available count to mlops, not from the local redis cache.