### PR TITLE
Fix generating environment variables from job configurations for multi-level nesting

### DIFF
--- a/python/fedml/computing/scheduler/comm_utils/job_utils.py
+++ b/python/fedml/computing/scheduler/comm_utils/job_utils.py
@@ -585,14 +585,14 @@ class JobRunnerUtils(Singleton):
             return {}
 
         for config_key, config_value in config_dict.items():
+            config_key = f"{config_key_path}_{config_key}".upper() if config_key_path else str(config_key).upper()
             if isinstance(config_value, dict):
                 JobRunnerUtils.get_env_from_dict(
                     export_cmd, config_value, export_env_command_list=export_env_command_list,
                     env_name_value_map=env_name_value_map, config_key_path=config_key
                 )
             else:
-                env_name = f"FEDML_ENV_{'' if config_key_path == '' else str(config_key_path).upper() + '_'}" \
-                           f"{str(config_key).upper()}"
+                env_name = f"FEDML_ENV_{config_key}"
                 config_value = str(config_value).replace("\n", ";")
                 config_value = str(config_value).replace("\"", "\\\"")
                 export_env_command_list.append(f"{export_cmd} {env_name}=\"{config_value}\"\n")


### PR DESCRIPTION
If the configuration path for `config_sub_key` is as follows:
```
config_parent_key:
    config_sub_key: config_sub_key_value
```

Then the equivalent environment variable should be as follows:
FEDML_ENV_uppercase($config_parent_key)_uppercase($config_sub_key)

This approach should be implemented recursively for any depth of nesting. However, there is currently a bug for nesting beyond two layers where it skips earlier level's config keys.

# Example Job yaml multi-level nesting:
```
level-1:
  level-2a:
    level-3a: $3000   
    level-3b: A100-80G

  level-2b: $3000
  level-2c: A100-80G
```


# Before this fix / Current Bug:
`env_name_value_map`
```
'FEDML_ENV_LEVEL-2A_LEVEL-3A' = '$3000'
'FEDML_ENV_LEVEL-2A_LEVEL-3B' = 'A100-80G'
'FEDML_ENV_LEVEL-1_LEVEL-2B' = '$3000'
'FEDML_ENV_LEVEL-1_LEVEL-2C' = 'A100-80G'
```


# After this fix:
`env_name_value_map`
```
'FEDML_ENV_LEVEL-1_LEVEL-2A_LEVEL-3A' = '$3000'
'FEDML_ENV_LEVEL-1_LEVEL-2A_LEVEL-3B' =  'A100-80G'
'FEDML_ENV_LEVEL-1_LEVEL-2B' = '$3000'
'FEDML_ENV_LEVEL-1_LEVEL-2C' = 'A100-80G'
```