### PR TITLE
Changing the help option displayed for adding user metadata to storag…

### DIFF
--- a/python/fedml/cli/modules/storage.py
+++ b/python/fedml/cli/modules/storage.py
@@ -50,8 +50,9 @@ def validate_argument(ctx, param, value):
                                              "the data file or directory name.")
 @click.option("--description", "-d", type=str, help="Add description to your data to store. If not provided, "
                                                     "the description will be empty.")
-@click.option("--user_metadata", "-um", type=str, help="User-defined metadata in the form of a name-value (key-value) "
-                                                       "pair. Defaults to None.")
+@click.option("--user_metadata", "-um", type=str, help="User-defined metadata in the form of a dictionary, for instance, "
+                                                       " {'name':'value'} within double quotes. "" "
+                                                       "Defaults to None.")
 @click.option('--service', "-s", type=click.Choice(['R2']), default="R2", help="Storage service for object storage. "
                                                                                "Only R2 is supported as of now")
 @click.option(


### PR DESCRIPTION
Change : The PR changes the help message displayed when using the command `fedml storage upload -h`. The change specifically changes the help message for the option -um : the option to enter user defined metadata. The key-value format doesn't work. It needs to be in dictionary format and it needs to be within quotes to pass the various checks in the code. This message reflects the necessary changes the user needs to do.