### PR TITLE
Update remote_storage.py

### DIFF
--- a/python/fedml/core/distributed/communication/s3/remote_storage.py
+++ b/python/fedml/core/distributed/communication/s3/remote_storage.py
@@ -672,3 +672,10 @@ class S3Storage:
             logging.error(f"Failed to fetch metadata for key {path_s3} after max retry.")
             return data, message
         return data, message
+
+    // TODO: 
+    async def upload_file_stream(self, file_stream, file_key):
+
+    // TODO: 
+    def generate_presigned_url(self, file_key) -> str:
+    


### PR DESCRIPTION
How can you expose two APIs here for external calls?

- upload_file_stream

An API for an **asynchronous** **stream** of file, and don't compress it. The reason why it is designed to be **asynchronous** is because sometimes we don't want the upload progress to block the main process.

- generate_presigned_url
Use `file_key` to get the pre-signed link to the file.
