### PR TITLE
[Fix]: fix the 2124 issue to ensure encryption of client model weights in Fed-ML HE example

### DIFF
--- a/python/fedml/core/fhe/fhe_agg.py
+++ b/python/fedml/core/fhe/fhe_agg.py
@@ -26,12 +26,9 @@ class FedMLFHE:
         return self.is_enabled
 
     def init(self, args):
-        if not self.is_enabled:
-            return
-
-        import tenseal as fhe_core
 
         if hasattr(args, "enable_fhe") and args.enable_fhe:
+            import tenseal as fhe_core
             logging.info(
                 ".......init homomorphic encryption......."
             )


### PR DESCRIPTION
[Fix]: fix the 2124 issue to ensure encryption of client model weights in Fed-ML HE example.