### PR TITLE
[fixbug]1.read inference proxy port  from config file 2.occupy_gpu_ids fail,get gpu ids from cache may return [] instead of None

### DIFF
--- a/python/fedml/computing/scheduler/comm_utils/job_utils.py
+++ b/python/fedml/computing/scheduler/comm_utils/job_utils.py
@@ -93,7 +93,7 @@ class JobRunnerUtils(Singleton):
                                  f" for run {run_id}: {available_gpu_ids}")
 
                     # If the available GPU list is not in the cache, set it to the current system available GPU list
-                    if available_gpu_ids is None:
+                    if available_gpu_ids is None or available_gpu_ids == []:
                         # Get realtime GPU availability list from the system
                         available_gpu_ids = JobRunnerUtils.get_realtime_gpu_available_ids().copy()
                         logging.info(f"Cache not set yet, fetching realtime available GPU Ids: {available_gpu_ids}")

--- a/python/fedml/computing/scheduler/model_scheduler/device_http_proxy_inference_protocol.py
+++ b/python/fedml/computing/scheduler/model_scheduler/device_http_proxy_inference_protocol.py
@@ -53,7 +53,8 @@ class FedMLHttpProxyInference:
             # TODO(Raphael): Add support for GET and other methods
     ):
         inference_response = {}
-        http_proxy_url = f"http://{urlparse(inference_url).hostname}:{ClientConstants.LOCAL_CLIENT_API_PORT}/api/v1/predict"
+        worker_proxy_port = ClientConstants.get_inference_worker_proxy_port()
+        http_proxy_url = f"http://{urlparse(inference_url).hostname}:{worker_proxy_port}/api/v1/predict"
         if inference_type == "default":
             model_api_headers = {'Content-Type': 'application/json', 'Connection': 'close',
                                  'Accept': 'application/json'}


### PR DESCRIPTION
1.The work inference proxy port needs to be read from the configuration file 2.occupy_gpu_ids fail,get gpu ids from cache may return [] instead of None